### PR TITLE
Combine and split legs in FusionTreeBackend

### DIFF
--- a/cyten/backends/fusion_tree_backend.py
+++ b/cyten/backends/fusion_tree_backend.py
@@ -1863,7 +1863,7 @@ class FusionTreeBackend(TensorBackend):
         XOR domain and `in_domain` specifies whether the mapping is to be applied to the
         domain or codomain; there is no use for it in the other case.
         """
-        backend = self.backend.block_backend
+        backend = self.block_backend
         new_data = FusionTreeData._zero_data(new_codomain, new_domain, backend, Dtype.complex128)
 
         # we allow this case for more efficient treatment when only c symbols in the (co)domain are involved

--- a/tests/pytest/linalg/test_backend_nonabelian.py
+++ b/tests/pytest/linalg/test_backend_nonabelian.py
@@ -8,7 +8,7 @@ import numpy as np
 from cyten.backends import fusion_tree_backend, get_backend
 from cyten.spaces import ElementarySpace, ProductSpace
 from cyten import backends
-from cyten.tensors import DiagonalTensor, SymmetricTensor, move_leg
+from cyten.tensors import DiagonalTensor, SymmetricTensor, move_leg, combine_legs
 from cyten.symmetries import ProductSymmetry, fibonacci_anyon_category, SU2Symmetry, SU3_3AnyonCategory
 from cyten.dtypes import Dtype
 
@@ -192,7 +192,7 @@ def assert_braiding_and_scale_axis_commutation(a: SymmetricTensor, funcs: list[C
 
 
 def assert_bending_up_and_down_trivial(codomains: list[ProductSpace], domains: list[ProductSpace],
-                                       funcs: list[Callable], backend: TensorBackend, multiple: bool, eps: float):
+                                       funcs: list[Callable], backend: backends.TensorBackend, multiple: bool, eps: float):
     """Check that bending a leg up and down (or down and up) is trivial. All given codomains are combined with all
     given domains to construct random tensors for which the identities are checked. All codomains and domains must
     have the same symmetry; this is not explicitly checked.
@@ -1523,3 +1523,25 @@ def test_b_symbol_su3_3(block_backend: str, np_random: np.random.Generator):
 
     # rescaling axis and then bending == bending and then rescaling axis
     assert_bending_and_scale_axis_commutation(tens, funcs, eps)
+
+
+def _test_combine_legs():
+    # sym = SU3_3AnyonCategory()
+    # e1 = ElementarySpace(sym, [[1], [2]], [1, 1])
+
+    sym = fibonacci_anyon_category
+    e1 = ElementarySpace(sym, [[0], [1]], [1, 2])
+    p1 = ProductSpace([e1, e1])
+    # p2 = ProductSpace([e1, p1])
+
+    # spc = ProductSpace([e1, e1])
+    spc = ProductSpace([e1, p1, e1, p1])
+
+    a = SymmetricTensor.from_random_uniform(spc, spc)
+    # 0 x 0 = 0: 0-5
+    # 1 x 1 = 0: 5-21
+    # 0 x 1 = 1: 0-8
+    # 1 x 0 = 1: 8-18
+    # 1 x 1 = 1: 18-34
+
+    combine_legs(a, [0, 1])


### PR DESCRIPTION
Early stage of implementing `combine_legs`.
This PR exists to save the progress in the case we decide to allow for combining and splitting in the `FusionTreeBackend` in the future. Right now, it is unclear if we actually want or need to allow for `ProductSpace`s on the tensorlegs in the `FusionTreeBackend` since doing so implies additional transformations, e.g., when bending legs.

Contains three finished (but not properly tested) helper functions and a rough implementation idea for `combine_legs` that is not finished yet. There are comments where parts are missing.