### PR TITLE
refactor zero_data

### DIFF
--- a/cyten/backends/abstract_backend.py
+++ b/cyten/backends/abstract_backend.py
@@ -765,8 +765,8 @@ class TensorBackend(metaclass=ABCMeta):
         return mask, err, new_norm
 
     @abstractmethod
-    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype, device: str
-                  ) -> Data:
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype, device: str,
+                  all_blocks: bool = False) -> Data:
         """Data for a zero tensor"""
         ...
 

--- a/cyten/backends/abstract_backend.py
+++ b/cyten/backends/abstract_backend.py
@@ -767,7 +767,10 @@ class TensorBackend(metaclass=ABCMeta):
     @abstractmethod
     def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype, device: str,
                   all_blocks: bool = False) -> Data:
-        """Data for a zero tensor"""
+        """Data for a zero tensor. Explicitly constructs the zero blocks corresponding to all
+        consistent sectors of the correct shape if `all_blocks == True`. Otherwise, the blocks
+        in the returned `Data` is an empty list.
+        """
         ...
 
     @abstractmethod

--- a/cyten/backends/no_symmetry.py
+++ b/cyten/backends/no_symmetry.py
@@ -446,7 +446,8 @@ class NoSymmetryBackend(TensorBackend):
         )
         return mask_data, new_leg, err, new_norm
 
-    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype, device: str):
+    def zero_data(self, codomain: ProductSpace, domain: ProductSpace, dtype: Dtype, device: str,
+                  all_blocks: bool = False) -> Data:
         return self.block_backend.zero_block(
             shape=[l.dim for l in conventional_leg_order(codomain, domain)],
             dtype=dtype, device=device

--- a/tests/pytest/linalg/test_backend_nonabelian.py
+++ b/tests/pytest/linalg/test_backend_nonabelian.py
@@ -1892,8 +1892,8 @@ def cross_check_single_b_symbol(ten: SymmetricTensor, bend_up: bool
     new_codomain = [new_space1, new_space2][bend_up]
     new_domain = [new_space1, new_space2][not bend_up]
 
-    new_data = ftb.FusionTreeData._zero_data(new_codomain, new_domain, block_backend,
-                                             dtype=Dtype.complex128, device=device)
+    new_data = ten.backend.zero_data(new_codomain, new_domain, dtype=Dtype.complex128,
+                                     device=device, all_blocks=True)
 
     for alpha_tree, beta_tree, tree_block in ftb._tree_block_iter(ten):
         modified_shape = [ten.codomain[i].sector_multiplicity(sec)


### PR DESCRIPTION
Allow to construct zero blocks in `zero_data` that correspond to all consistent sectors in the correct shapes