### PR TITLE
Fix decompositions

### DIFF
--- a/cyten/tensors.py
+++ b/cyten/tensors.py
@@ -3692,7 +3692,7 @@ def eigh(tensor: Tensor, new_labels: str | list[str] | None, new_leg_dual: bool,
         tensor = combine_legs(
             tensor,
             range(tensor.num_codomain_legs), range(tensor.num_codomain_legs, tensor.num_legs),
-            pipe_dualities=[new_leg_dual, new_leg_dual]
+            pipe_dualities=[new_leg_dual, not new_leg_dual]
         )
 
     # first, compute a decomposition where the new leg is a ket space
@@ -3703,7 +3703,7 @@ def eigh(tensor: Tensor, new_labels: str | list[str] | None, new_leg_dual: bool,
 
     # undo the combine
     if not tensor.backend.can_decompose_tensors:
-        V = split_legs(V, -1)
+        V = split_legs(V, 0)
 
     # if required, flip the leg duality
     if new_leg_dual != new_leg.is_dual:

--- a/tests/python_tests/test_tensors.py
+++ b/tests/python_tests/test_tensors.py
@@ -2182,12 +2182,6 @@ def test_svd(cls, dom, cod, new_leg_dual, make_compatible_tensor):
 
     print('Normal (non-truncated) SVD')
 
-    # TODO
-    if isinstance(T.backend, backends.AbelianBackend):
-        with pytest.raises(NotImplementedError):
-            _ = tensors.svd(T, new_labels=['a', 'b', 'c', 'd'], new_leg_dual=new_leg_dual)
-        pytest.xfail()
-
     U, S, Vh = tensors.svd(T, new_labels=['a', 'b', 'c', 'd'], new_leg_dual=new_leg_dual)
     U.test_sanity()
     S.test_sanity()

--- a/tests/python_tests/test_tensors.py
+++ b/tests/python_tests/test_tensors.py
@@ -1407,9 +1407,7 @@ def test_eigh(cls, dom, new_leg_dual, make_compatible_tensor):
     T.set_labels(list('efghijk')[:2 * dom])
     T.test_sanity()
 
-    if isinstance(T.backend, backends.AbelianBackend) and cls is not DiagonalTensor:
-        with pytest.raises(AssertionError):
-            _ = tensors.eigh(T, new_labels=['a', 'b', 'c'], new_leg_dual=new_leg_dual)
+    if isinstance(T.backend, backends.AbelianBackend) and cls is not DiagonalTensor and T.num_legs != 2:
         pytest.xfail()
 
     W, V = tensors.eigh(T, new_labels=['a', 'b', 'c'], new_leg_dual=new_leg_dual)

--- a/tests/python_tests/test_tensors.py
+++ b/tests/python_tests/test_tensors.py
@@ -2027,12 +2027,6 @@ def test_qr_lq(cls, dom, cod, new_leg_dual, make_compatible_tensor):
     T_labels = list('efghijk')[:dom + cod]
     T: cls = make_compatible_tensor(dom, cod, cls=cls, labels=T_labels)
 
-    # TODO
-    if isinstance(T.backend, backends.AbelianBackend):
-        with pytest.raises(NotImplementedError):
-            _ = tensors.qr(T, new_leg_dual=new_leg_dual)
-        pytest.xfail()
-
     Q, R = tensors.qr(T, new_leg_dual=new_leg_dual)
     Q.test_sanity()
     R.test_sanity()


### PR DESCRIPTION
Fix abelian `svd`, `lq` and `qr`, fix `eigh` for two-leg tensors.

The more general case fix of `eigh` seems to be related to fixing `combine_legs` and will be done elsewhere.