### PR TITLE
MPO tensors

### DIFF
--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -29,6 +29,7 @@ from ..symmetries import (
     SymmetryError,
     U1Symmetry,
     ZNSymmetry,
+    Sector
 )
 from ..tensors import DiagonalTensor, SymmetricTensor
 from ..tools import as_immutable_array, is_iterable, to_iterable, to_valid_idx
@@ -148,6 +149,16 @@ class Site:
                 understood_braiding=understood_braiding,
             )
         self.onsite_operators[name] = op
+
+    @abstractmethod
+    def get_mpo_building_block(self, label: str) -> SymmetricTensor:
+        """FIXME"""
+        ...
+
+    @abstractmethod
+    def mpo_building_block_basis(self, a: Sector, b: Sector) -> list[int]:
+        """"""
+        ...
 
     def state_index(self, label: str | int) -> int:
         """The index of a basis state."""


### PR DESCRIPTION
Different strategy:
- In sites, cache a basis for four-leg tensors, with labels
- use this basis when decomposing couplings into mini MPOs
- can use these labels in the MPO graph
- Maybe keep the current idea anyway, for later. It basically encodes the IdL and IdR ideas.
- Name?
  - mpo_building_block is bad
  - maybe CBD (coupling building block)