### PR TITLE
Unify numpy array compare in tests

### DIFF
--- a/tests/python_tests/backends/test_fusion_tree_backend.py
+++ b/tests/python_tests/backends/test_fusion_tree_backend.py
@@ -8,6 +8,7 @@ from math import prod
 
 import numpy as np
 import pytest
+from numpy import testing as npt
 
 from cyten import backends
 from cyten.backends import fusion_tree_backend, get_backend
@@ -62,10 +63,10 @@ def test_c_symbol_fibonacci_anyons(block_backend: str, np_random: np.random.Gene
     C_ttttt1 = phi**-0.5 * R_tau * R_1.conj()
     C_tttt1t = phi**-0.5 * R_tau.conj()
     C_tttttt = -1 * phi**-1
-    assert np.allclose(sym.c_symbol(tau, tau, tau, tau, vac, vac), C_tttt11)
-    assert np.allclose(sym.c_symbol(tau, tau, tau, tau, tau, vac), C_ttttt1)
-    assert np.allclose(sym.c_symbol(tau, tau, tau, tau, vac, tau), C_tttt1t)
-    assert np.allclose(sym.c_symbol(tau, tau, tau, tau, tau, tau), C_tttttt)
+    npt.assert_almost_equal(sym.c_symbol(tau, tau, tau, tau, vac, vac), C_tttt11)
+    npt.assert_almost_equal(sym.c_symbol(tau, tau, tau, tau, tau, vac), C_ttttt1)
+    npt.assert_almost_equal(sym.c_symbol(tau, tau, tau, tau, vac, tau), C_tttt1t)
+    npt.assert_almost_equal(sym.c_symbol(tau, tau, tau, tau, tau, tau), C_tttttt)
     # R_1=-0.8090-0.5878j  R_tau=-0.3090+0.9511j
     # C_tttt11=-0.5000+0.3633j   C_tttt1t=-0.2429-0.7477j   C_ttttt1=-0.2429-0.7477j   C_tttttt=-0.6180
 

--- a/tests/python_tests/models/test_couplings.py
+++ b/tests/python_tests/models/test_couplings.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import pytest
+from numpy import testing as npt
 
 import cyten
 from cyten import SymmetryError, backends, tensors
@@ -129,10 +130,10 @@ def test_coupling(codom, make_compatible_space):
     assert tensors.almost_equal(coupling.to_tensor(), T)
     if T.symmetry.can_be_dropped:
         coupling_to_numpy = coupling.to_numpy(understood_braiding=True)
-        assert np.allclose(coupling_to_numpy, T.to_numpy(understood_braiding=True))
+        npt.assert_almost_equal(coupling_to_numpy, T.to_numpy(understood_braiding=True))
         coupling2 = couplings.Coupling.from_dense_block(coupling_to_numpy, site_list, understood_braiding=True)
         coupling2.test_sanity()
-        assert np.all(coupling2.sites == coupling.sites)
+        npt.assert_array_equal(coupling2.sites, coupling.sites)
         for i in range(codom):
             assert tensors.almost_equal(coupling2.factorization[i], coupling.factorization[i])
 
@@ -168,7 +169,7 @@ def test_spin_spin_coupling(any_backend, np_random):
             # hermiticity
             assert tensors.almost_equal(tensor.hc, tensor)
             # trace is zero
-            assert np.allclose(tensors.trace(tensor), 0)
+            npt.assert_almost_equal(tensors.trace(tensor), 0)
             if site1 == site2:
                 # commutation relation
                 tensor_commuted = tensors.permute_legs(tensor, codomain=[1, 0], domain=[2, 3])
@@ -197,7 +198,7 @@ def test_spin_spin_coupling(any_backend, np_random):
                 evs = tensor.to_numpy(leg_order=[0, 1, 3, 2], understood_braiding=True)
                 evs = np.reshape(evs, (np.prod(evs.shape[:2]), -1))
                 evs = np.sort(np.linalg.eigvalsh(evs))
-                assert np.allclose(evs, np.sort(Jz * expect_evs))
+                npt.assert_almost_equal(evs, np.sort(Jz * expect_evs))
 
     check_coupling(couplings.spin_spin_coupling, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=False)
 
@@ -221,7 +222,7 @@ def test_spin_field_coupling(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         # check eigenvalues
         h = np.sqrt(hx**2 + hy**2 + hz**2)
         if isinstance(site, sites.SpinSite):
@@ -231,7 +232,7 @@ def test_spin_field_coupling(any_backend, np_random):
             expect_evs = np.array([0, 0, -0.5, 0.5])
         evs = tensor.to_numpy(understood_braiding=True)
         evs = np.sort(np.linalg.eigvalsh(evs))
-        assert np.allclose(evs, np.sort(h * expect_evs))
+        npt.assert_almost_equal(evs, np.sort(h * expect_evs))
 
     check_coupling(couplings.spin_field_coupling, site_num=1, invalid_site_nums=[2], boson_fermion_mixing=False)
 
@@ -269,10 +270,10 @@ def test_aklt_coupling(any_backend, np_random):
             evs = tensor.to_numpy(leg_order=[0, 1, 3, 2], understood_braiding=True)
             evs = np.reshape(evs, (np.prod(evs.shape[:2]), -1))
             evs = np.sort(np.linalg.eigvalsh(evs))
-            assert np.allclose(evs, np.sort(J * expect_evs))
+            npt.assert_almost_equal(evs, np.sort(J * expect_evs))
             if site1 == site2 and isinstance(site1, sites.SpinSite) and site1.double_total_spin == 2:
                 # actual AKLT case
-                assert np.allclose(evs, J * np.array([-2.0 / 3.0] * 4 + [4.0 / 3.0] * 5))
+                npt.assert_almost_equal(evs, J * np.array([-2.0 / 3.0] * 4 + [4.0 / 3.0] * 5))
 
     check_coupling(couplings.aklt_coupling, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=False)
 
@@ -295,7 +296,7 @@ def test_chiral_3spin_coupling(any_backend, np_random):
             # hermiticity
             assert tensors.almost_equal(tensor.hc, tensor)
             # trace is zero
-            assert np.allclose(tensors.trace(tensor), 0)
+            npt.assert_almost_equal(tensors.trace(tensor), 0)
             if site1 == site2:
                 # cyclic permutation relation
                 tensor_commuted = tensors.permute_legs(tensor, codomain=[2, 0, 1], domain=[3, 5, 4])
@@ -337,7 +338,7 @@ def test_chemical_potential(any_backend, np_random):
             expect_evs.append(-mu * sum([occupations[k] for k in species]))
         evs = tensor.to_numpy(understood_braiding=True)
         evs = np.sort(np.linalg.eigvalsh(evs))
-        assert np.allclose(evs, np.sort(expect_evs))
+        npt.assert_almost_equal(evs, np.sort(expect_evs))
 
     check_coupling(couplings.chemical_potential, site_num=1, invalid_site_nums=[2], boson_fermion_mixing=False, mu=1.0)
 
@@ -371,7 +372,7 @@ def test_onsite_interaction(any_backend, np_random):
             expect_evs.append(U * n**2 / 2.0)
         evs = tensor.to_numpy(understood_braiding=True)
         evs = np.sort(np.linalg.eigvalsh(evs))
-        assert np.allclose(evs, np.sort(expect_evs))
+        npt.assert_almost_equal(evs, np.sort(expect_evs))
 
     check_coupling(couplings.onsite_interaction, site_num=1, invalid_site_nums=[2], boson_fermion_mixing=False)
 
@@ -415,7 +416,7 @@ def test_density_density_interaction(any_backend, np_random):
         evs = tensor.to_numpy(leg_order=[0, 1, 3, 2], understood_braiding=True)
         evs = np.reshape(evs, (np.prod(evs.shape[:2]), -1))
         evs = np.sort(np.linalg.eigvalsh(evs))
-        assert np.allclose(evs, np.sort(expect_evs))
+        npt.assert_almost_equal(evs, np.sort(expect_evs))
 
     check_coupling(
         couplings.density_density_interaction, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=True
@@ -459,7 +460,7 @@ def test_hopping(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         # if there is a permutation s.t. species1 <-> species2, we can commute the legs
         symmetric = False
         for perm in it.permutations(range(len(species1))):
@@ -515,7 +516,7 @@ def test_pairing(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         # if there is a permutation s.t. species1 <-> species2, we can commute the legs
         symmetric = False
         for perm in it.permutations(range(len(species1))):
@@ -565,12 +566,12 @@ def test_onsite_pairing(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         if isinstance(site, degrees_of_freedom.FermionicDOF):
             # default case is trivial for fermions
             coupling = couplings.onsite_pairing([site], Delta=1)
             coupling.test_sanity()
-            assert np.allclose(tensors.norm(coupling.to_tensor()), 0)
+            npt.assert_almost_equal(tensors.norm(coupling.to_tensor()), 0)
 
     check_coupling(couplings.onsite_pairing, site_num=1, invalid_site_nums=[2], boson_fermion_mixing=False)
 
@@ -588,7 +589,7 @@ def test_clock_clock_coupling(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         # commutation relation
         tensor_commuted = tensors.permute_legs(tensor, codomain=[1, 0], domain=[2, 3])
         tensor_commuted.relabel({'p0': 'p1', 'p1': 'p0', 'p0*': 'p1*', 'p1*': 'p0*'})
@@ -609,13 +610,13 @@ def test_clock_field_coupling(any_backend, np_random):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace is zero
-        assert np.allclose(tensors.trace(tensor), 0)
+        npt.assert_almost_equal(tensors.trace(tensor), 0)
         # check eigenvalues
         if isinstance(site.leg.symmetry.factors[0], cyten.ZN):
             expect_evs = 2 * np.cos(np.linspace(0, 2 * np.pi, site.q, endpoint=False))
             evs = tensor.to_numpy(understood_braiding=True)
             evs = np.sort(np.linalg.eigvalsh(evs))
-            assert np.allclose(evs, np.sort(hz * expect_evs))
+            npt.assert_almost_equal(evs, np.sort(hz * expect_evs))
 
     check_coupling(couplings.clock_field_coupling, site_num=1, invalid_site_nums=[2], boson_fermion_mixing=False)
 
@@ -636,7 +637,7 @@ def test_sector_projection_coupling(block_backend):
         # trace is integer * dim(sector)
         dim_sec = site.symmetry.qdim(sector)
         tr = tensors.trace(tensor)
-        assert np.allclose(np.round(tr / dim_sec, 0), tr / dim_sec)
+        npt.assert_almost_equal(np.round(tr / dim_sec, 0), tr / dim_sec)
 
 
 def test_gold_coupling(block_backend):
@@ -649,7 +650,7 @@ def test_gold_coupling(block_backend):
         # hermiticity
         assert tensors.almost_equal(tensor.hc, tensor)
         # trace
-        assert np.allclose(tensors.trace(tensor), [-1, -2][i])
+        npt.assert_almost_equal(tensors.trace(tensor), [-1, -2][i])
 
     coupling = couplings.gold_coupling(site_list, J=1.0)
     coupling.test_sanity()
@@ -657,6 +658,6 @@ def test_gold_coupling(block_backend):
     # hermiticity
     assert tensors.almost_equal(tensor.hc, tensor)
     # trace
-    assert np.allclose(tensors.trace(tensor), -1)
+    npt.assert_almost_equal(tensors.trace(tensor), -1)
 
     check_coupling(couplings.gold_coupling, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=False)

--- a/tests/python_tests/models/test_site.py
+++ b/tests/python_tests/models/test_site.py
@@ -104,8 +104,8 @@ def test_spin_site(any_backend, spin):
         sz = site.spin_vector[:, :, 2]
         down = site.state_labels['down']
         up = site.state_labels['up']
-        assert np.allclose(sz[down, down], -1 * spin)
-        assert np.allclose(sz[up, up], spin)
+        npt.assert_almost_equal(sz[down, down], -1 * spin)
+        npt.assert_almost_equal(sz[up, up], spin)
 
         expect_ops = {}
         if conserve in ['Sz', 'parity', 'None']:
@@ -138,10 +138,10 @@ def test_spinless_boson_site(any_backend, np_random, Nmax):
         site.test_sanity()
 
         vac = site.state_labels['vac']
-        assert np.allclose(site.n_tot[vac, vac], 0)
+        npt.assert_almost_equal(site.n_tot[vac, vac], 0)
         for i in range(Nmax):
             state = site.state_labels[str(i)]
-            assert np.allclose(site.n_tot[state, state], i)
+            npt.assert_almost_equal(site.n_tot[state, state], i)
 
         expect_ops = dict(N0=True, N=True, Ntot=True)
         expect_ops.update(N0N0=True, NN=True, NtotNtot=True)
@@ -179,12 +179,12 @@ def test_spinless_boson_site(any_backend, np_random, Nmax):
         site.test_sanity()
 
         vac = site.state_labels['vac']
-        assert np.allclose(site.n_tot[vac, vac], 0)
+        npt.assert_almost_equal(site.n_tot[vac, vac], 0)
         for i in range(Nmax):
             for j in range(Nmax2):
                 state = site.state_labels[f'({i}, {j})']
-                assert np.allclose(site.number_operators[state, state, 0], i)
-                assert np.allclose(site.number_operators[state, state, 1], j)
+                npt.assert_almost_equal(site.number_operators[state, state, 0], i)
+                npt.assert_almost_equal(site.number_operators[state, state, 1], j)
 
         expect_ops = dict(N0=True, N1=True, Ntot=True)
         expect_ops.update(N0N0=True, N1N1=True, NtotNtot=True)
@@ -211,16 +211,16 @@ def test_spinless_fermion_site(block_backend, np_random, num_species):
         site.test_sanity()
 
         vac = site.state_labels['vac']
-        assert np.allclose(site.n_tot[vac, vac], 0)
+        npt.assert_almost_equal(site.n_tot[vac, vac], 0)
         if num_species == 1:
             assert site.state_labels['0'] == vac
             state = site.state_labels['1']
-            assert np.allclose(site.n_tot[state, state], 1)
+            npt.assert_almost_equal(site.n_tot[state, state], 1)
         else:
             for occupations in it.product([0, 1], repeat=num_species):
                 state = site.state_labels[str(occupations)]
                 for k in range(num_species):
-                    assert np.allclose(site.number_operators[state, state, k], occupations[k])
+                    npt.assert_almost_equal(site.number_operators[state, state, k], occupations[k])
 
         expect_ops = {f'N{k}': True for k in range(num_species)}
         expect_ops.update(Ntot=True, Ptot=True, NtotNtot=True)
@@ -255,9 +255,9 @@ def test_spin_half_fermion_site(block_backend, np_random):
         assert site.state_labels['full'] == site.state_labels['(1, 1)']
         for occupations in it.product([0, 1], repeat=2):
             state = site.state_labels[str(occupations)]
-            assert np.allclose(site.number_operators[state, state, 0], occupations[0])  # spin up
-            assert np.allclose(site.number_operators[state, state, 1], occupations[1])  # spin down
-            assert np.allclose(site.spin_vector[state, state, 2], 0.5 * (occupations[0] - occupations[1]))
+            npt.assert_almost_equal(site.number_operators[state, state, 0], occupations[0])  # spin up
+            npt.assert_almost_equal(site.number_operators[state, state, 1], occupations[1])  # spin down
+            npt.assert_almost_equal(site.spin_vector[state, state, 2], 0.5 * (occupations[0] - occupations[1]))
 
         expect_ops = dict(Ntot=True, Ptot=True, NtotNtot=True)
         if conserve_S in ['Sz', 'parity', 'None']:
@@ -294,10 +294,10 @@ def test_clock_site(any_backend, q):
 
         z = site.clock_operators[:, :, 1]
         up = site.state_labels['up']
-        assert np.allclose(z[up, up], 1)
+        npt.assert_almost_equal(z[up, up], 1)
         if q % 2 == 0:
             down = site.state_labels['down']
-            assert np.allclose(z[down, down], -1)
+            npt.assert_almost_equal(z[down, down], -1)
         else:
             assert 'down' not in site.state_labels
 

--- a/tests/python_tests/test_krylov_based.py
+++ b/tests/python_tests/test_krylov_based.py
@@ -40,7 +40,7 @@ def test_lanczos_gs(compatible_backend, make_compatible_space, N_cache, tol):
 
     H_np = H.to_numpy()
     H_op = sparse.TensorLinearOperator(H, which_leg=1)
-    npt.assert_allclose(H_np, H_np.conj().transpose())  # make sure we generated a hermitian operator
+    npt.assert_almost_equal(H_np, H_np.conj().transpose())  # make sure we generated a hermitian operator
     E_np, psi_np = np.linalg.eigh(H_np)
     E0_np, psi0_np = E_np[0], psi_np[:, 0]
 
@@ -139,7 +139,7 @@ def test_lanczos_evolve(compatible_backend, make_compatible_space, N_cache, tol)
         return
 
     H_np = H.to_numpy()
-    npt.assert_allclose(H_np, H_np.conj().transpose())  # make sure we generated a hermitian operator
+    npt.assert_almost_equal(H_np, H_np.conj().transpose())  # make sure we generated a hermitian operator
 
     sector = leg.sector_decomposition[0]
     psi_init = tensors.ChargedTensor.random_uniform(legs=[leg], charge=sector, backend=backend, dummy_leg_state=[1])

--- a/tests/python_tests/test_planar.py
+++ b/tests/python_tests/test_planar.py
@@ -265,7 +265,7 @@ def test_planar_contraction(
         assert ct.planar.planar_almost_equal(res, expect)
     else:
         assert len(contr_A) == A.num_legs and len(contr_B) == B.num_legs
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
 
 @pytest.mark.parametrize(
@@ -1067,7 +1067,7 @@ def test_PlanarDiagram_with_traces(symmetry, np_random):
     expect1 = ct.planar.planar_contraction(expect1, T3_traced, ['vR'], ['vL'])
     expect1 = ct.planar.planar_contraction(expect1, T4_traced, ['vL', 'vR'], ['vL', 'vR'])
     assert isinstance(expect1, (float, complex))
-    assert np.allclose(expect1, res)
+    npt.assert_almost_equal(expect1, res)
 
     # ===========================================
     # compare to manual contraction, using general (not planar) routines
@@ -1087,7 +1087,7 @@ def test_PlanarDiagram_with_traces(symmetry, np_random):
         ct.permute_legs(T4_traced_, codomain=['vL', 'vR'], bend_right=True),
     )
     assert isinstance(expect2, (float, complex))
-    assert np.allclose(expect2, res)
+    npt.assert_almost_equal(expect2, res)
 
 
 def test_PlanarDiagram_verify_diagram():

--- a/tests/python_tests/test_spaces.py
+++ b/tests/python_tests/test_spaces.py
@@ -109,7 +109,7 @@ def test_ElementarySpace(any_symmetry, make_any_sectors, np_random):
                     sector_idx, mult_idx = s1.parse_index(idx)
                     assert sector_idx == n_sector
                     assert mult_idx == m * d + mu
-                    assert np.all(s1.idx_to_sector(idx) == sector)
+                    npt.assert_array_equal(s1.idx_to_sector(idx), sector)
                     idx += 1
 
     print('check sector lookup')
@@ -182,8 +182,8 @@ def test_ElementarySpace_from_defining_sectors(any_symmetry, make_any_sectors, n
         np.all(sectors[None, :, :] == expect_sectors[:, None, :], axis=2), multiplicities[None, :], 0
     )
     expect_mults = np.sum(mult_contributions, axis=1)
-    assert np.all(res.sector_decomposition == expect_sectors)
-    assert np.all(res.multiplicities == expect_mults)
+    npt.assert_array_equal(res.sector_decomposition, expect_sectors)
+    npt.assert_array_equal(res.multiplicities, expect_mults)
     #
     # check basis perm
     if any_symmetry.can_be_dropped:
@@ -419,7 +419,7 @@ def test_AbelianLegPipe(abelian_group_symmetry, combine_cstyle, pipe_dual, np_ra
     start = 0
     for sector, mult in zip(leg_1.sector_decomposition, leg_1.multiplicities):
         for b in internal_basis_1[start : start + mult]:
-            assert np.all(b[0] == sector)
+            npt.assert_array_equal(b[0], sector)
         start = start + mult
     assert start == leg_1.dim
 
@@ -434,7 +434,7 @@ def test_AbelianLegPipe(abelian_group_symmetry, combine_cstyle, pipe_dual, np_ra
         for s_1, s_2 in iter_combinations(leg_1.sector_decomposition, leg_2.sector_decomposition)
     ]
     fusion_outcomes_sorted, expect = _sort_sectors(fusion_outcomes, abelian_group_symmetry, by_duals=pipe.is_dual)
-    assert np.all(pipe.fusion_outcomes_sort == expect)
+    npt.assert_array_equal(pipe.fusion_outcomes_sort, expect)
 
     # check block_ind_map_slices
     # =======================================
@@ -457,12 +457,12 @@ def test_AbelianLegPipe(abelian_group_symmetry, combine_cstyle, pipe_dual, np_ra
         [b[0] for b in internal_fusion_outcomes], abelian_group_symmetry, by_duals=pipe.is_dual
     )
 
-    assert np.all(pipe._get_fusion_outcomes_perm(pipe.multiplicities) == fusion_outcomes_perm)
+    npt.assert_array_equal(pipe._get_fusion_outcomes_perm(pipe.multiplicities), fusion_outcomes_perm)
 
     # check basis_perm
     # =======================================
     assert pipe.basis_perm.shape == (pipe.dim,)
-    assert np.all(np.sort(pipe.basis_perm) == np.arange(pipe.dim))
+    npt.assert_array_equal(np.sort(pipe.basis_perm), np.arange(pipe.dim))
     public_basis_pipe = [
         (abelian_group_symmetry.fusion_outcomes(b_1[0], b_2[0])[0], b_1[1], b_2[1])
         for b_1, b_2 in iter_combinations(public_basis_1, public_basis_2)
@@ -480,7 +480,7 @@ def test_AbelianLegPipe(abelian_group_symmetry, combine_cstyle, pipe_dual, np_ra
         else:  # else == "no break occurred"
             raise RuntimeError  # should not happen
 
-    assert np.all(pipe.basis_perm == np.array(expect_perm))
+    npt.assert_array_equal(pipe.basis_perm, np.array(expect_perm))
 
 
 @pytest.mark.parametrize('is_dual', [True, False])
@@ -509,8 +509,8 @@ def test_direct_sum(is_dual, make_any_space, max_mult=5, max_sectors=5):
         expected_order = np.lexsort(d.sector_decomposition.T)
     else:
         expected_order = slice(None, None, None)
-    assert np.all(d.sector_decomposition[expected_order] == sectors)
-    assert np.all(d.multiplicities[expected_order] == mults)
+    npt.assert_array_equal(d.sector_decomposition[expected_order], sectors)
+    npt.assert_array_equal(d.multiplicities[expected_order], mults)
 
 
 def test_str_repr(make_any_space, any_symmetry, str_max_lines=20, repr_max_lines=20):
@@ -620,10 +620,10 @@ def test_swap_gate(symm, basis_perm, abelian_pipes, np_random, V_pipe, W_pipe, V
     # -> it is now enough to check that the phases are as expected
 
     # they must be complex phases
-    npt.assert_allclose(np.abs(phases), 1)
+    npt.assert_almost_equal(np.abs(phases), 1)
 
     if symm.has_trivial_braid:
-        npt.assert_allclose(phases, +1)
+        npt.assert_almost_equal(phases, +1)
 
     elif symm is fermion_parity:
         if V_pipe is False:
@@ -650,7 +650,7 @@ def test_swap_gate(symm, basis_perm, abelian_pipes, np_random, V_pipe, W_pipe, V
 
         for j in range(dW):
             for i in range(dV):
-                assert np.allclose(phases[j, i], 1 - 2 * V_parity[i] * W_parity[j])
+                npt.assert_almost_equal(phases[j, i], 1 - 2 * V_parity[i] * W_parity[j])
         npt.assert_almost_equal(phases, 1 - 2 * V_parity[None, :] * W_parity[:, None])
 
     else:
@@ -666,11 +666,11 @@ def assert_spaces_equal(space1: spaces.Space, space2: spaces.Space):
         assert space1.is_dual == space2.is_dual, 'mismatched is_dual'
         assert space1.symmetry == space2.symmetry, 'mismatched symmetry'
         assert space1.num_sectors == space2.num_sectors, 'mismatched num_sectors'
-        assert np.all(space1.multiplicities == space2.multiplicities), 'mismatched multiplicities'
-        assert np.all(space1.sector_decomposition == space2.sector_decomposition), 'mismatched sectors'
+        npt.assert_array_equal(space1.multiplicities, space2.multiplicities), 'mismatched multiplicities'
+        npt.assert_array_equal(space1.sector_decomposition, space2.sector_decomposition), 'mismatched sectors'
         if (space1._basis_perm is not None) or (space2._basis_perm is not None):
             # otherwise both are trivial and this match
-            assert np.all(space1.basis_perm == space2.basis_perm), 'mismatched basis_perm'
+            npt.assert_array_equal(space1.basis_perm, space2.basis_perm), 'mismatched basis_perm'
     elif isinstance(space1, spaces.TensorProduct):
         assert isinstance(space2, spaces.TensorProduct), 'mismatching types'
         assert space1.num_factors == space2.num_factors

--- a/tests/python_tests/test_symmetries.py
+++ b/tests/python_tests/test_symmetries.py
@@ -4,7 +4,7 @@ import os.path
 import h5py
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy import testing as npt
 
 from cyten import symmetries
 from cyten.block_backends.dtypes import _numpy_dtype_to_cyten
@@ -247,10 +247,10 @@ def common_checks(
     for a in example_sectors:
         fusion = sym.fusion_outcomes(a, sym.trivial_sector)
         assert len(fusion) == 1
-        assert_array_equal(fusion[0], a)
+        npt.assert_array_equal(fusion[0], a)
 
     # trivial sector is its own dual
-    assert_array_equal(sym.dual_sector(sym.trivial_sector), sym.trivial_sector)
+    npt.assert_array_equal(sym.dual_sector(sym.trivial_sector), sym.trivial_sector)
 
     # check fusion tensors, if available
     if sym.can_be_dropped and not skip_fusion_tensor:
@@ -293,29 +293,29 @@ def common_checks(
     # check derived topological data vs the fallback implementations.
     for a in example_sectors:
         if sym.can_be_dropped:
-            assert_array_almost_equal(
+            npt.assert_almost_equal(
                 sym.Z_iso(a), symmetries.SymmetryFactor.Z_iso(sym, a), err_msg='Z_iso does not match fallback'
             )
         assert sym.frobenius_schur(a) == symmetries.SymmetryFactor.frobenius_schur(sym, a), (
             'frobenius_schur does not match fallback'
         )
         # note: need almost equal for non-integer qdim
-        assert_array_almost_equal(
+        npt.assert_almost_equal(
             sym.qdim(a), symmetries.SymmetryFactor.qdim(sym, a), err_msg='qdim does not match fallback'
         )
-        assert_array_almost_equal(
+        npt.assert_almost_equal(
             sym.topological_twist(a),
             symmetries.SymmetryFactor.topological_twist(sym, a),
             err_msg='topological_twist does not match fallback',
         )
     for a, b, c in sector_triplets:
-        assert_array_almost_equal(
+        npt.assert_almost_equal(
             sym._b_symbol(a, b, c),
             symmetries.SymmetryFactor._b_symbol(sym, a, b, c),
             err_msg='B symbol does not match fallback',
         )
     for c, a, b, d, e, f in sector_sextets:
-        assert_array_almost_equal(
+        npt.assert_almost_equal(
             sym._c_symbol(a, b, c, d, e, f),
             symmetries.SymmetryFactor._c_symbol(sym, a, b, c, d, e, f),
             err_msg='C symbol does not match fallback',
@@ -324,13 +324,13 @@ def common_checks(
     # check braiding style
     for a in example_sectors:  # check topological twist
         if sym.braiding_style == symmetries.BraidingStyle.bosonic:
-            assert_array_almost_equal(sym.topological_twist(a), 1)
+            npt.assert_almost_equal(sym.topological_twist(a), 1)
         elif sym.braiding_style == symmetries.BraidingStyle.fermionic:
-            assert_array_almost_equal(sym.topological_twist(a) ** 2, 1)
+            npt.assert_almost_equal(sym.topological_twist(a) ** 2, 1)
 
     if sym.braiding_style.value <= symmetries.BraidingStyle.fermionic.value:  # check R symbols
         for a, b, c in sector_triplets:
-            assert_array_almost_equal(sym.r_symbol(a, b, c) ** 2, np.ones(sym.n_symbol(a, b, c)))
+            npt.assert_almost_equal(sym.r_symbol(a, b, c) ** 2, np.ones(sym.n_symbol(a, b, c)))
 
     # check fusion style
     if sym.is_abelian:
@@ -380,7 +380,7 @@ def check_fusion_tensor(sym: symmetries.Symmetry, example_sectors, np_random):
             # orthonormal?
             res = np.tensordot(Y_abc, X_abc, [[1, 2], [1, 2]])  # [mu', m_c', mu, m_c]
             expect = np.eye(N_abc)[:, None, :, None] * np.eye(sym.sector_dim(c))[None, :, None, :]
-            assert_array_almost_equal(res, expect)
+            npt.assert_almost_equal(res, expect)
 
             # accumulate projector for checking completeness after the loop
             completeness_res += np.tensordot(X_abc, Y_abc, [[0, 3], [0, 3]])
@@ -388,7 +388,7 @@ def check_fusion_tensor(sym: symmetries.Symmetry, example_sectors, np_random):
         # complete?
         eye_a = np.eye(d_a)[:, None, :, None]
         eye_b = np.eye(d_b)[None, :, None, :]
-        assert_array_almost_equal(completeness_res, eye_a * eye_b)
+        npt.assert_almost_equal(completeness_res, eye_a * eye_b)
 
         # remains: orthonormality for different sectors
         for c, d in sample_offdiagonal(fusion_outcomes, num_samples=5, accept_fewer=True, np_rng=np_random):
@@ -400,7 +400,7 @@ def check_fusion_tensor(sym: symmetries.Symmetry, example_sectors, np_random):
             X_abd = sym.fusion_tensor(a, b, d)
             res = np.tensordot(Y_abc, X_abd, [[1, 2], [1, 2]])  # [mu', m_c', mu, m_d]
             expect = np.zeros((N_abc, d_c, N_abd, d_d), dtype=res.dtype)
-            assert_array_almost_equal(res, expect)
+            npt.assert_almost_equal(res, expect)
 
     for a in example_sectors:
         d_a = sym.sector_dim(a)
@@ -410,24 +410,24 @@ def check_fusion_tensor(sym: symmetries.Symmetry, example_sectors, np_random):
         Z_a_bar = sym.Z_iso(a_bar)  # [m_abar, m_a]
 
         # Z iso unitary?
-        assert_array_almost_equal(Z_a @ Z_a_hc, np.eye(d_a))
-        assert_array_almost_equal(Z_a_hc @ Z_a, np.eye(d_a))
+        npt.assert_almost_equal(Z_a @ Z_a_hc, np.eye(d_a))
+        npt.assert_almost_equal(Z_a_hc @ Z_a, np.eye(d_a))
 
         # defining property of frobenius schur?
-        assert_array_almost_equal(Z_a.T, sym.frobenius_schur(a) * Z_a_bar)
+        npt.assert_almost_equal(Z_a.T, sym.frobenius_schur(a) * Z_a_bar)
 
         # reduces to left/right unitor if one input is trivial?  [Jakob thesis, (5.63)
         X_aua = sym.fusion_tensor(a, sym.trivial_sector, a)
-        assert_array_almost_equal(X_aua, np.eye(d_a, dtype=X_aua.dtype)[None, :, None, :])
+        npt.assert_almost_equal(X_aua, np.eye(d_a, dtype=X_aua.dtype)[None, :, None, :])
         X_uaa = sym.fusion_tensor(sym.trivial_sector, a, a)
-        assert_array_almost_equal(X_uaa, np.eye(d_a, dtype=X_uaa.dtype)[None, None, :, :])
+        npt.assert_almost_equal(X_uaa, np.eye(d_a, dtype=X_uaa.dtype)[None, None, :, :])
 
         # relationship to cup  [Jakob thesis, (5.84)]
         Y = sym.fusion_tensor(a, a_bar, sym.trivial_sector).conj()[0, :, :, 0]  # [m_a, m_abar]
         expect_1 = Z_a.T / np.sqrt(d_a)  # transpose [m_a, m_abar] -> [m_a, m_abar]
         expect_2 = sym.frobenius_schur(a) / np.sqrt(d_a) * Z_a_bar
-        assert_array_almost_equal(Y, expect_1)
-        assert_array_almost_equal(Y, expect_2)
+        npt.assert_almost_equal(Y, expect_1)
+        npt.assert_almost_equal(Y, expect_2)
 
 
 def check_symbols_via_fusion_tensors(sym: symmetries.Symmetry, sector_triplets, sector_sextets, np_random):
@@ -455,7 +455,7 @@ def check_symbols_via_fusion_tensors(sym: symmetries.Symmetry, sector_triplets, 
         F = sym.f_symbol(a, b, c, d, e, f)
         id_d = np.eye(sym.sector_dim(d))
         expect = F[..., None, None] * id_d[None, None, None, None, :, :]
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
     # ================
     # R symbol
@@ -474,7 +474,7 @@ def check_symbols_via_fusion_tensors(sym: symmetries.Symmetry, sector_triplets, 
         R = sym.r_symbol(a, b, c)  # [mu, nu]
         id_c = np.eye(sym.sector_dim(c))  # [c, c]
         expect = np.diag(R)[:, :, None, None] * id_c[None, None, :, :]
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
     # ================
     # C symbol
@@ -497,7 +497,7 @@ def check_symbols_via_fusion_tensors(sym: symmetries.Symmetry, sector_triplets, 
         C = sym.c_symbol(a, b, c, d, e, f)
         id_d = np.eye(sym.sector_dim(d))
         expect = C[..., None, None] * id_d[None, None, None, None, :, :]
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
     # ================
     # B symbol
@@ -518,7 +518,7 @@ def check_symbols_via_fusion_tensors(sym: symmetries.Symmetry, sector_triplets, 
         B = sym.b_symbol(a, b, c)
         id_a = np.eye(sym.sector_dim(a))
         expect = B[:, :, None, None] * id_a[None, None, :, :]
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
 
 def check_F_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_test):
@@ -529,11 +529,11 @@ def check_F_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_t
         F = sym.f_symbol(a, b, c, d, e, f)
 
         if not sym.has_complex_topological_data:
-            assert np.allclose(F, np.real(F))
+            npt.assert_almost_equal(F, np.real(F))
 
         assert F.shape == shape  # shape
         if np.any([np.array_equal(charge, sym.trivial_sector) for charge in [a, b, c]]):
-            assert_array_almost_equal(F, np.eye(shape[0] * shape[1]).reshape(shape))  # for trivial sector
+            npt.assert_almost_equal(F, np.eye(shape[0] * shape[1]).reshape(shape))  # for trivial sector
 
     for charges in sector_unitarity_test:  # unitarity
         a, b, c, d, e, g = charges
@@ -546,9 +546,9 @@ def check_F_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_t
                 F2 = sym.f_symbol(a, b, c, d, g, f).conj()
                 res += np.tensordot(F1, F2, axes=[[2, 3], [2, 3]])
         if np.array_equal(e, g):
-            assert_array_almost_equal(res, np.eye(shape[0] * shape[1]).reshape(shape))
+            npt.assert_almost_equal(res, np.eye(shape[0] * shape[1]).reshape(shape))
         else:
-            assert_array_almost_equal(res, np.zeros(shape))
+            npt.assert_almost_equal(res, np.zeros(shape))
 
 
 def check_R_symbols(sym: symmetries.Symmetry, sector_triplets, example_sectors_low_qdim):
@@ -559,13 +559,13 @@ def check_R_symbols(sym: symmetries.Symmetry, sector_triplets, example_sectors_l
         R = sym.r_symbol(a, b, c)
 
         if not sym.has_complex_topological_data:
-            assert np.allclose(R, np.real(R))
+            npt.assert_almost_equal(R, np.real(R))
 
         assert R.shape == shape  # shape
-        assert_array_almost_equal(np.abs(R), np.ones(shape))  # unitarity
+        npt.assert_almost_equal(np.abs(R), np.ones(shape))  # unitarity
 
         if np.any([np.array_equal(charge, sym.trivial_sector) for charge in [a, b]]):
-            assert_array_almost_equal(R, np.ones_like(R))  # exchange with trivial sector
+            npt.assert_almost_equal(R, np.ones_like(R))  # exchange with trivial sector
 
 
 def check_C_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_test):
@@ -576,11 +576,11 @@ def check_C_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_t
         C = sym.c_symbol(a, b, c, d, e, f)
 
         if not sym.has_complex_topological_data:
-            assert np.allclose(C, np.real(C))
+            npt.assert_almost_equal(C, np.real(C))
 
         assert C.shape == shape  # shape
         if np.any([np.array_equal(charge, sym.trivial_sector) for charge in [b, c]]):
-            assert_array_almost_equal(C, np.eye(shape[0] * shape[1]).reshape(shape))  # for trivial sector
+            npt.assert_almost_equal(C, np.eye(shape[0] * shape[1]).reshape(shape))  # for trivial sector
 
     for charges in sector_unitarity_test:  # unitarity
         c, a, b, d, e, g = charges
@@ -593,9 +593,9 @@ def check_C_symbols(sym: symmetries.Symmetry, sector_sextets, sector_unitarity_t
                 C2 = sym.c_symbol(a, b, c, d, g, f).conj()
                 res += np.tensordot(C1, C2, axes=[[2, 3], [2, 3]])
         if np.array_equal(e, g):
-            assert_array_almost_equal(res, np.eye(shape[0] * shape[1]).reshape(shape))
+            npt.assert_almost_equal(res, np.eye(shape[0] * shape[1]).reshape(shape))
         else:
-            assert_array_almost_equal(res, np.zeros(shape))
+            npt.assert_almost_equal(res, np.zeros(shape))
 
 
 def check_B_symbols(sym: symmetries.Symmetry, sector_triplets):
@@ -606,15 +606,15 @@ def check_B_symbols(sym: symmetries.Symmetry, sector_triplets):
         B = sym.b_symbol(a, b, c)
 
         if not sym.has_complex_topological_data:
-            assert np.allclose(B, np.real(B))
+            npt.assert_almost_equal(B, np.real(B))
 
         assert B.shape == shape  # shape
 
         norm = np.diag(np.ones(shape[0])) * sym.qdim(c) / sym.qdim(a)
-        assert_array_almost_equal(np.tensordot(B, B.conj(), axes=[1, 1]), norm)  # normalization
+        npt.assert_almost_equal(np.tensordot(B, B.conj(), axes=[1, 1]), norm)  # normalization
 
         snake = np.tensordot(B, sym.b_symbol(c, sym.dual_sector(b), a), axes=[1, 1])  # snake eq.
-        assert_array_almost_equal(snake, sym.frobenius_schur(b) * np.diag(np.ones(shape[0])))
+        npt.assert_almost_equal(snake, sym.frobenius_schur(b) * np.diag(np.ones(shape[0])))
 
 
 def check_pentagon_equation(sym: symmetries.Symmetry, sector_nonets):
@@ -641,7 +641,7 @@ def check_pentagon_equation(sym: symmetries.Symmetry, sector_nonets):
                 rhs_ = np.tensordot(rhs_, sym.f_symbol(b, c, d, i, j, h), axes=([0, 3], [2, 3]))  # [μ, ν, κ, ρ, γ, δ]
                 rhs += rhs_
 
-        assert_array_almost_equal(lhs, rhs)
+        npt.assert_almost_equal(lhs, rhs)
 
 
 def check_hexagon_equation(sym: symmetries.Symmetry, sector_sextets, check_both_versions: bool = True):
@@ -688,7 +688,7 @@ def check_hexagon_equation(sym: symmetries.Symmetry, sector_sextets, check_both_
                     _rhs = np.tensordot(_rhs, sym.f_symbol(a, b, c, d, g, f), axes=([0, 3], [2, 3]))  # [α, β, μ, ν]
                     rhs += _rhs
 
-            assert_array_almost_equal(lhs, rhs)
+            npt.assert_almost_equal(lhs, rhs)
 
 
 def test_no_symmetry(np_random):
@@ -707,11 +707,11 @@ def test_no_symmetry(np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(s, s), np.array([[0]]))
+    npt.assert_array_equal(sym.fusion_outcomes(s, s), np.array([[0]]))
 
     print('checking fusion_outcomes_broadcast')
     many_s = np.stack([s, s, s])
-    assert_array_equal(sym.fusion_outcomes_broadcast(many_s, many_s), many_s)
+    npt.assert_array_equal(sym.fusion_outcomes_broadcast(many_s, many_s), many_s)
 
     # print('checking sector dimensions')
     # nothing to do, the dimension of the only sector (trivial) is checked in common_checks
@@ -728,10 +728,10 @@ def test_no_symmetry(np_random):
     assert not sym.is_equivalent_to(symmetries.SU2() * symmetries.u1_symmetry)
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(s), s)
+    npt.assert_array_equal(sym.dual_sector(s), s)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(many_s), many_s)
+    npt.assert_array_equal(sym.dual_sectors(many_s), many_s)
 
 
 # @pytest.mark.xfail(reason='Topological data not implemented.')
@@ -746,7 +746,7 @@ def test_product_symmetry(np_random):
         np_random=np_random,
     )
     assert doubleFibo._f_symbol([0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]) == 1
-    assert np.isclose(
+    npt.assert_almost_equal(
         doubleFibo._f_symbol([1, 1], [1, 1], [1, 1], [1, 1], [1, 1], [1, 1])[0, 0, 0, 0],
         1 / ((0.5 * (1 + np.sqrt(5))) ** 2),
     )
@@ -759,9 +759,9 @@ def test_product_symmetry(np_random):
             example_sectors_low_qdim=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1], [1, 2], [2, 2], [0, 2], [2, 0]]),
             np_random=np_random,
         )
-        assert np.isclose(doubleIsing._r_symbol([1, 1], [1, 1], [0, 0]), 1)
-        assert np.isclose(doubleIsing._r_symbol([1, 1], [2, 2], [1, 1]), 1)
-        assert np.isclose(doubleIsing._r_symbol([2, 2], [1, 1], [1, 1]), 1)
+        npt.assert_almost_equal(doubleIsing._r_symbol([1, 1], [1, 1], [0, 0]), 1)
+        npt.assert_almost_equal(doubleIsing._r_symbol([1, 1], [2, 2], [1, 1]), 1)
+        npt.assert_almost_equal(doubleIsing._r_symbol([2, 2], [1, 1], [1, 1]), 1)
 
     sym = symmetries.Symmetry([symmetries.SU2(), symmetries.U1(), symmetries.FermionParity()])
     sym_with_name = symmetries.Symmetry([symmetries.SU2('foo'), symmetries.U1('bar'), symmetries.FermionParity()])
@@ -806,14 +806,14 @@ def test_product_symmetry(np_random):
     outcomes = sym.fusion_outcomes(s1, s2)
     # spin 3/2 and 5/2 can fuse to [1, 2, 3, 4]  ;  U(1) charges  3 + 2 = 5  ;  fermion charges 1 + 0 = 1
     expect = np.array([[2, 5, 1], [4, 5, 1], [6, 5, 1], [8, 5, 1]])
-    assert_array_equal(outcomes, expect)
+    npt.assert_array_equal(outcomes, expect)
 
     print('checking fusion_outcomes_broadcast')
     with pytest.raises(AssertionError):
         # sym is not abelian, so this should raise
         _ = sym.fusion_outcomes_broadcast(s1[None, :], s2[None, :])
     outcomes = u1_z3.fusion_outcomes_broadcast(np.array([[42, 2], [-2, 0]]), np.array([[1, 1], [2, 1]]))
-    assert_array_equal(outcomes, np.array([[43, 0], [0, 1]]))
+    npt.assert_array_equal(outcomes, np.array([[43, 0], [0, 1]]))
 
     print('checking sector dimensions')
     assert sym.sector_dim(s1) == 6
@@ -832,11 +832,11 @@ def test_product_symmetry(np_random):
     assert not sym.is_equivalent_to(symmetries.no_symmetry)
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(s1), np.array([5, -3, 1]))
-    assert_array_equal(sym.dual_sector(s2), np.array([3, -2, 0]))
+    npt.assert_array_equal(sym.dual_sector(s1), np.array([5, -3, 1]))
+    npt.assert_array_equal(sym.dual_sector(s2), np.array([3, -2, 0]))
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(np.stack([s1, s2])), np.array([[5, -3, 1], [3, -2, 0]]))
+    npt.assert_array_equal(sym.dual_sectors(np.stack([s1, s2])), np.array([[5, -3, 1], [3, -2, 0]]))
 
 
 def test_u1_symmetry(np_random):
@@ -861,12 +861,12 @@ def test_u1_symmetry(np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(s_1, s_1), s_2[None, :])
-    assert_array_equal(sym.fusion_outcomes(s_neg1, s_1), s_0[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(s_1, s_1), s_2[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(s_neg1, s_1), s_0[None, :])
 
     print('checking fusion_outcomes_broadcast')
     outcomes = sym.fusion_outcomes_broadcast(np.stack([s_0, s_1, s_0]), np.stack([s_neg1, s_1, s_2]))
-    assert_array_equal(outcomes, np.stack([s_neg1, s_2, s_2]))
+    npt.assert_array_equal(outcomes, np.stack([s_neg1, s_2, s_2]))
 
     print('checking sector dimensions')
     for s in [s_0, s_1, s_neg1, s_2, s_42]:
@@ -887,10 +887,10 @@ def test_u1_symmetry(np_random):
     assert not sym.is_equivalent_to(symmetries.SU2() * symmetries.u1_symmetry)
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(s_1), s_neg1)
+    npt.assert_array_equal(sym.dual_sector(s_1), s_neg1)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(np.stack([s_0, s_1, s_42, s_2])), np.array([0, -1, -42, -2])[:, None])
+    npt.assert_array_equal(sym.dual_sectors(np.stack([s_0, s_1, s_42, s_2])), np.array([0, -1, -42, -2])[:, None])
 
 
 @pytest.mark.parametrize('N', [2, 3, 4, 42])
@@ -917,11 +917,11 @@ def test_ZN_symmetry(N, np_random):
     for a in sectors_a:
         for b in sectors_b:
             expect = (a + b)[None, :] % N
-            assert_array_equal(sym.fusion_outcomes(a, b), expect)
+            npt.assert_array_equal(sym.fusion_outcomes(a, b), expect)
 
     print('checking fusion_outcomes_broadcast')
     expect = (sectors_a + sectors_b) % N
-    assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
+    npt.assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
 
     print('checking sector dimensions')
     for s in sectors_a:
@@ -944,10 +944,10 @@ def test_ZN_symmetry(N, np_random):
 
     print('checking dual_sector')
     for s in sectors_a:
-        assert_array_equal(sym.dual_sector(s), (-s) % N)
+        npt.assert_array_equal(sym.dual_sector(s), (-s) % N)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
+    npt.assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
 
 
 def test_su2_symmetry(np_random):
@@ -976,7 +976,7 @@ def test_su2_symmetry(np_random):
 
     print('checking fusion_outcomes')
     # 1 x 3/2 = 1/2 + 3/2 + 5/2
-    assert_array_equal(sym.fusion_outcomes(spin_1, spin_3_half), np.array([[1], [3], [5]]))
+    npt.assert_array_equal(sym.fusion_outcomes(spin_1, spin_3_half), np.array([[1], [3], [5]]))
 
     print('checking fusion_outcomes_broadcast')
     with pytest.raises(AssertionError):
@@ -994,11 +994,11 @@ def test_su2_symmetry(np_random):
     assert sym != symmetries.fermion_parity
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(spin_1), spin_1)
-    assert_array_equal(sym.dual_sector(spin_3_half), spin_3_half)
+    npt.assert_array_equal(sym.dual_sector(spin_1), spin_1)
+    npt.assert_array_equal(sym.dual_sector(spin_3_half), spin_3_half)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(np.stack([spin_1, spin_3_half])), np.stack([spin_1, spin_3_half]))
+    npt.assert_array_equal(sym.dual_sectors(np.stack([spin_1, spin_3_half])), np.stack([spin_1, spin_3_half]))
 
 
 @pytest.mark.parametrize('N', [3])
@@ -1079,11 +1079,11 @@ def test_fermion_parity(np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(odd, odd), even[None, :])
-    assert_array_equal(sym.fusion_outcomes(odd, even), odd[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(odd, odd), even[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(odd, even), odd[None, :])
 
     print('checking fusion_outcomes_broadcast')
-    assert_array_equal(
+    npt.assert_array_equal(
         sym.fusion_outcomes_broadcast(np.stack([even, even, odd]), np.stack([even, odd, odd])),
         np.stack([even, odd, even]),
     )
@@ -1102,10 +1102,10 @@ def test_fermion_parity(np_random):
     assert not sym.is_equivalent_to(symmetries.SU2())
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(odd), odd)
+    npt.assert_array_equal(sym.dual_sector(odd), odd)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(np.stack([odd, even, odd])), np.stack([odd, even, odd]))
+    npt.assert_array_equal(sym.dual_sectors(np.stack([odd, even, odd])), np.stack([odd, even, odd]))
 
 
 def test_fermion_number(np_random):
@@ -1125,11 +1125,11 @@ def test_fermion_number(np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(np.array([1]), np.array([1])), np.array([[2]]))
-    assert_array_equal(sym.fusion_outcomes(np.array([1]), np.array([-1])), np.array([[0]]))
+    npt.assert_array_equal(sym.fusion_outcomes(np.array([1]), np.array([1])), np.array([[2]]))
+    npt.assert_array_equal(sym.fusion_outcomes(np.array([1]), np.array([-1])), np.array([[0]]))
 
     print('checking fusion_outcomes_broadcast')
-    assert_array_equal(sym.fusion_outcomes_broadcast(example_sectors, 2 * example_sectors), 3 * example_sectors)
+    npt.assert_array_equal(sym.fusion_outcomes_broadcast(example_sectors, 2 * example_sectors), 3 * example_sectors)
 
     print('checking equality')
     assert sym == sym
@@ -1145,10 +1145,10 @@ def test_fermion_number(np_random):
     assert not sym.is_equivalent_to(symmetries.SU2())
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(np.array([2])), np.array([-2]))
+    npt.assert_array_equal(sym.dual_sector(np.array([2])), np.array([-2]))
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(example_sectors), -example_sectors)
+    npt.assert_array_equal(sym.dual_sectors(example_sectors), -example_sectors)
 
 
 @pytest.mark.parametrize('handedness', ['left', 'right'])
@@ -1173,8 +1173,8 @@ def test_fibonacci_grading(handedness, np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion rules')
-    assert_array_equal(sym.fusion_outcomes(vac, tau), tau[None, :])
-    assert_array_equal(sym.fusion_outcomes(tau, tau), np.stack([vac, tau]))
+    npt.assert_array_equal(sym.fusion_outcomes(vac, tau), tau[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(tau, tau), np.stack([vac, tau]))
 
     print('checking equality')
     assert sym == sym
@@ -1191,7 +1191,7 @@ def test_fibonacci_grading(handedness, np_random):
     assert not sym.is_equivalent_to(symmetries.SU2())
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(tau), tau)
+    npt.assert_array_equal(sym.dual_sector(tau), tau)
 
 
 @pytest.mark.parametrize('nu', [*range(1, 16, 2)])
@@ -1217,10 +1217,10 @@ def test_ising_grading(nu, np_random):
     assert not sym.is_valid_sector(np.array([0, 0]))
 
     print('checking fusion rules')
-    assert_array_equal(sym.fusion_outcomes(vac, anyon), anyon[None, :])
-    assert_array_equal(sym.fusion_outcomes(vac, fermion), fermion[None, :])
-    assert_array_equal(sym.fusion_outcomes(anyon, fermion), anyon[None, :])
-    assert_array_equal(sym.fusion_outcomes(anyon, anyon), np.stack([vac, fermion]))
+    npt.assert_array_equal(sym.fusion_outcomes(vac, anyon), anyon[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(vac, fermion), fermion[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(anyon, fermion), anyon[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(anyon, anyon), np.stack([vac, fermion]))
 
     print('checking equality')
     assert sym == sym
@@ -1237,8 +1237,8 @@ def test_ising_grading(nu, np_random):
     assert not sym.is_equivalent_to(symmetries.SU2())
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(anyon), anyon)
-    assert_array_equal(sym.dual_sector(fermion), fermion)
+    npt.assert_array_equal(sym.dual_sector(anyon), anyon)
+    npt.assert_array_equal(sym.dual_sector(fermion), fermion)
 
 
 def test_SU3_3AnyonCategory(np_random):
@@ -1263,12 +1263,12 @@ def test_SU3_3AnyonCategory(np_random):
         assert not sym.is_valid_sector(np.array(invalid))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(b, b), np.stack([a, b, c, d]))
-    assert_array_equal(sym.fusion_outcomes(b, c), b[None, :])
-    assert_array_equal(sym.fusion_outcomes(b, d), b[None, :])
-    assert_array_equal(sym.fusion_outcomes(c, c), d[None, :])
-    assert_array_equal(sym.fusion_outcomes(c, d), a[None, :])
-    assert_array_equal(sym.fusion_outcomes(d, d), c[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(b, b), np.stack([a, b, c, d]))
+    npt.assert_array_equal(sym.fusion_outcomes(b, c), b[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(b, d), b[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(c, c), d[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(c, d), a[None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(d, d), c[None, :])
 
     print('checking equality')
     assert sym == sym
@@ -1281,12 +1281,12 @@ def test_SU3_3AnyonCategory(np_random):
     assert not sym.is_equivalent_to(symmetries.SU2())
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(b), b)
-    assert_array_equal(sym.dual_sector(c), d)
-    assert_array_equal(sym.dual_sector(d), c)
+    npt.assert_array_equal(sym.dual_sector(b), b)
+    npt.assert_array_equal(sym.dual_sector(c), d)
+    npt.assert_array_equal(sym.dual_sector(d), c)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(np.stack([a, b, c, d])), np.stack([a, b, d, c]))
+    npt.assert_array_equal(sym.dual_sectors(np.stack([a, b, c, d])), np.stack([a, b, d, c]))
 
 
 @pytest.mark.parametrize('N', [4, 7, 36])
@@ -1319,11 +1319,11 @@ def test_ZNAnyonCategories(cls, N, n, np_random):
     for a in sectors_a:
         for b in sectors_b:
             expect = (a + b)[None, :] % N
-            assert_array_equal(sym.fusion_outcomes(a, b), expect)
+            npt.assert_array_equal(sym.fusion_outcomes(a, b), expect)
 
     print('checking fusion_outcomes_broadcast')
     expect = (sectors_a + sectors_b) % N
-    assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
+    npt.assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
 
     print('checking sector dimensions')
     for s in sectors_a:
@@ -1353,10 +1353,10 @@ def test_ZNAnyonCategories(cls, N, n, np_random):
 
     print('checking dual_sector')
     for s in sectors_a:
-        assert_array_equal(sym.dual_sector(s), (-s) % N)
+        npt.assert_array_equal(sym.dual_sector(s), (-s) % N)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
+    npt.assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
 
 
 @pytest.mark.parametrize('N', [3, 8, 31])
@@ -1383,11 +1383,11 @@ def test_QuantumDoubleZNAnyonCategory(N, np_random):
     for a in sectors_a:
         for b in sectors_b:
             expect = (a + b)[None, :] % N
-            assert_array_equal(sym.fusion_outcomes(a, b), expect)
+            npt.assert_array_equal(sym.fusion_outcomes(a, b), expect)
 
     print('checking fusion_outcomes_broadcast')
     expect = (sectors_a + sectors_b) % N
-    assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
+    npt.assert_array_equal(sym.fusion_outcomes_broadcast(sectors_a, sectors_b), expect)
 
     print('checking sector dimensions')
     for s in sectors_a:
@@ -1416,10 +1416,10 @@ def test_QuantumDoubleZNAnyonCategory(N, np_random):
 
     print('checking dual_sector')
     for s in sectors_a:
-        assert_array_equal(sym.dual_sector(s), (-s) % N)
+        npt.assert_array_equal(sym.dual_sector(s), (-s) % N)
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
+    npt.assert_array_equal(sym.dual_sectors(sectors_a), (-sectors_a) % N)
 
 
 @pytest.mark.parametrize('k', [3, 4, 6])
@@ -1442,12 +1442,12 @@ def test_SU2_kAnyonCategory(k, handedness, np_random):
         assert not sym.is_valid_sector(np.array(invalid))
 
     print('checking fusion_outcomes')
-    assert_array_equal(sym.fusion_outcomes(sectors_a[-1], sectors_a[-1]), sectors_a[0][None, :])
-    assert_array_equal(sym.fusion_outcomes(sectors_a[-1], sectors_a[-2]), sectors_a[1][None, :])
-    assert_array_equal(sym.fusion_outcomes(sectors_a[-2], sectors_a[-2]), sectors_a[0:4:2])
+    npt.assert_array_equal(sym.fusion_outcomes(sectors_a[-1], sectors_a[-1]), sectors_a[0][None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(sectors_a[-1], sectors_a[-2]), sectors_a[1][None, :])
+    npt.assert_array_equal(sym.fusion_outcomes(sectors_a[-2], sectors_a[-2]), sectors_a[0:4:2])
     a, b = sectors_a[2][0], sectors_a[-3][0]
     limit = min(a + b, 2 * k - a - b)
-    assert_array_equal(sym.fusion_outcomes(sectors_a[2], sectors_a[-3]), sectors_a[abs(a - b) : limit + 2 : 2])
+    npt.assert_array_equal(sym.fusion_outcomes(sectors_a[2], sectors_a[-3]), sectors_a[abs(a - b) : limit + 2 : 2])
 
     print('checking equality')
     assert sym == sym
@@ -1456,11 +1456,11 @@ def test_SU2_kAnyonCategory(k, handedness, np_random):
     assert sym != symmetries.SU2()
 
     print('checking dual_sector')
-    assert_array_equal(sym.dual_sector(sectors_a[-1]), sectors_a[-1])
-    assert_array_equal(sym.dual_sector(sectors_b[-1]), sectors_b[-1])
+    npt.assert_array_equal(sym.dual_sector(sectors_a[-1]), sectors_a[-1])
+    npt.assert_array_equal(sym.dual_sector(sectors_b[-1]), sectors_b[-1])
 
     print('checking dual_sectors')
-    assert_array_equal(sym.dual_sectors(sectors_a), sectors_a)
+    npt.assert_array_equal(sym.dual_sectors(sectors_a), sectors_a)
 
 
 # test_suN_symmetry(3,'/space/ge36xeh/TenpyV2a/Test_N_3_HWeight_7.hdf5', '/space/ge36xeh/TenpyV2a/Test_Fsymb_3_HWeight_3.hdf5', '/space/ge36xeh/TenpyV2a/Test_Rsymb_3_HWeight_4.hdf5', default_rng)

--- a/tests/python_tests/test_tensors.py
+++ b/tests/python_tests/test_tensors.py
@@ -172,7 +172,7 @@ def test_SymmetricTensor(make_compatible_tensor, leg_nums, use_pipes):
     )
     tens.test_sanity()
     tens_np = tens.to_numpy(understood_braiding=True)
-    npt.assert_allclose(tens_np, numpy_block)
+    npt.assert_almost_equal(tens_np, numpy_block)
 
     can_have_non_symmetric_dense_blocks = T.num_parameters < T.size
 
@@ -233,8 +233,13 @@ def test_SymmetricTensor_from_eye(make_compatible_space, make_compatible_tensor,
             )
         else:
             raise RuntimeError('Need to adjust test design')
-        npt.assert_allclose(expect_from_backend, expect_explicit)
-        npt.assert_allclose(res, expect_explicit, rtol=1e-7, atol=1e-10)
+        npt.assert_array_almost_equal_nulp(expect_from_backend, expect_explicit, 10)
+        if T2.symmetry.is_abelian:
+            # should be exactly the eye blocks
+            npt.assert_array_almost_equal_nulp(res, expect_explicit, 100)
+        else:
+            # composing fusion tensors should introduce some floating point errors
+            npt.assert_array_almost_equal(res, expect_explicit, decimal=10)
 
 
 @pytest.mark.parametrize('leg_nums', [(1, 1), (2, 1), (3, 0), (0, 3)], ids=['1->1', '1->2', '0->3', '3->0'])
@@ -400,7 +405,7 @@ def test_SymmetricTensor_from_tree_pairs(make_compatible_tensor, leg_nums, np_ra
                 expect[(*codom_idcs, *reversed(dom_idcs))] += contribution
             expect = numpy_block_backend.apply_basis_perm(expect, conventional_leg_order(T_res), inv=True)
 
-            npt.assert_array_almost_equal(T_np, expect)
+            npt.assert_almost_equal(T_np, expect)
 
     # TODO test to_dense_block_trivial_sector
     # def OLD_test_Tensor_tofrom_dense_block_trivial_sector(make_compatible_tensor):
@@ -461,7 +466,7 @@ def test_fixes_124(np_random):
         dom_idcs = [slice(*l.slices[l.sector_decomposition_where(b)]) for l, b in zip(T.domain, Y.uncoupled)]
         expect[(*codom_idcs, *reversed(dom_idcs))] += contribution
     expect = backend.block_backend.apply_basis_perm(expect, conventional_leg_order(T), inv=True)
-    npt.assert_array_almost_equal(T_np, expect)
+    npt.assert_almost_equal(T_np, expect)
 
 
 def test_fixes_23():
@@ -471,7 +476,7 @@ def test_fixes_23():
     block = np.zeros((2,) * 6, float)
     tens = SymmetricTensor.from_dense_block(block, codomain=[site] * 3, domain=[site] * 3)
     tens.test_sanity()
-    npt.assert_allclose(tensors.norm(tens), 0)
+    npt.assert_almost_equal(tensors.norm(tens), 0)
 
 
 def test_DiagonalTensor(make_compatible_tensor):
@@ -532,7 +537,7 @@ def test_Identity(compatible_backend, make_compatible_space, make_compatible_ten
 
     if tens.symmetry.can_be_dropped:
         t_np = tens.to_numpy(understood_braiding=True)
-        npt.assert_allclose(t_np, np.eye(leg.dim))
+        npt.assert_almost_equal(t_np, np.eye(leg.dim))
 
     assert tensors.almost_equal(tens, eye_diag, allow_different_types=True)
     assert tensors.almost_equal(tens, eye_symm, allow_different_types=True)
@@ -670,7 +675,7 @@ def test_Mask(make_compatible_tensor, compatible_symmetry_backend, np_random):
     if symmetry.can_be_dropped:
         res_via_Symmetric = M_SymmetricTensor.to_numpy(understood_braiding=True)
         res_direct = M_projection.to_numpy(understood_braiding=True)
-        npt.assert_allclose(res_via_Symmetric, res_direct)
+        npt.assert_almost_equal(res_via_Symmetric, res_direct)
     print('   also for inclusion Mask')
     M_SymmetricTensor = M_inclusion.as_SymmetricTensor()
     assert M_SymmetricTensor.shape == M_inclusion.shape
@@ -678,7 +683,7 @@ def test_Mask(make_compatible_tensor, compatible_symmetry_backend, np_random):
     if symmetry.can_be_dropped:
         res_via_Symmetric = M_SymmetricTensor.to_numpy(understood_braiding=True)
         res_direct = M_inclusion.to_numpy(understood_braiding=True)
-        npt.assert_allclose(res_via_Symmetric, res_direct)
+        npt.assert_almost_equal(res_via_Symmetric, res_direct)
 
     # TODO check binary operands: &, ==, !=, &, |, ^ :
     #   left and right
@@ -850,7 +855,7 @@ def test_explicit_blocks(symmetry_backend, block_backend):
             npt.assert_array_almost_equal_nulp(t.backend.block_backend.to_numpy(actual), expect, 100)
 
     elif symmetry_backend == 'fusion_tree':
-        assert np.all(t.data.block_inds == np.array([0, 0])[None, :])
+        npt.assert_array_equal(t.data.block_inds, np.array([0, 0])[None, :])
         forest_block_00 = block_00.reshape((-1, 1))
         forest_block_22 = block_22.reshape((-1, 1))
         forest_block_31 = block_31.reshape((-1, 1))
@@ -1017,10 +1022,10 @@ def test_explicit_blocks(symmetry_backend, block_backend):
 
     elif symmetry_backend == 'fusion_tree':
         # check block_inds. first make sure the (co)domain.sector_decomposition are what we expect
-        assert np.all(t.codomain.sector_decomposition == np.stack([q0, q1, q2, q3]))
-        assert np.all(t.domain.sector_decomposition == np.stack([q0, q1, q2, q3]))
+        npt.assert_array_equal(t.codomain.sector_decomposition, np.stack([q0, q1, q2, q3]))
+        npt.assert_array_equal(t.domain.sector_decomposition, np.stack([q0, q1, q2, q3]))
         # expect coupled sectors [q0, q1, q2, q3]
-        assert np.all(t.data.block_inds == np.repeat(np.arange(4)[:, None], 2, axis=1))
+        npt.assert_array_equal(t.data.block_inds, np.repeat(np.arange(4)[:, None], 2, axis=1))
         #
         # build the blocks for fixed coupled sectors
         # note: when setting the data we listed the uncoupled sectors of the domain
@@ -1075,7 +1080,7 @@ def test_from_block_su2_symm(symmetry_backend, block_backend):
         labels=[['p1', 'p2'], ['p1*', 'p2*']],
     )
     tens_4.test_sanity()
-    assert np.all(tens_4.data.block_inds == np.array([[0, 0], [1, 1]]))  # spin 0, spin 1
+    npt.assert_array_equal(tens_4.data.block_inds, np.array([[0, 0], [1, 1]]))  # spin 0, spin 1
     # The blocks are the eigenvalue of the Heisenberg coupling in the fixed total spin sectors
     # For singlet states (coupled=spin-0), we have eigenvalue -3/4
     # For triplet states (coupled=spin-1), we have eigenvalue +1/4
@@ -1386,7 +1391,7 @@ def test_bend_legs(cls, codomain, domain, num_codomain_legs, make_compatible_ten
     if tensor.symmetry.can_be_dropped:
         tensor_np = tensor.to_numpy(understood_braiding=True)
         res_np = res.to_numpy(understood_braiding=True)
-        npt.assert_allclose(res_np, tensor_np)
+        npt.assert_almost_equal(res_np, tensor_np)
 
     bent_back = tensors.bend_legs(tensor, num_codomain_legs=tensor.num_codomain_legs)
     bent_back.test_sanity()
@@ -1538,19 +1543,19 @@ def test_combine_split(use_pipes, make_compatible_tensor):
 
         expect1 = np.reshape(T_np, (a * b, c, d))
         combined1_np = combined1.to_numpy(understood_braiding=True)
-        assert np.allclose(combined1_np, expect1)
+        npt.assert_almost_equal(combined1_np, expect1)
 
         expect2 = np.reshape(T_np, (a, b, c * d))
         combined2_np = combined2.to_numpy(understood_braiding=True)
-        assert np.allclose(combined2_np, expect2)
+        npt.assert_almost_equal(combined2_np, expect2)
 
         combined3_np = combined3.to_numpy(understood_braiding=True)
         expect3 = np.reshape(swap_gate_numpy.transpose(T_np, T.legs, [1, 0, 2, 3]), (a * b, c, d))
-        assert np.allclose(combined3_np, expect3)
+        npt.assert_almost_equal(combined3_np, expect3)
 
         expect4 = np.reshape(T_np, (a, b * c, d))
         combined4_np = combined4.to_numpy(understood_braiding=True)
-        assert np.allclose(combined4_np, expect4)
+        npt.assert_almost_equal(combined4_np, expect4)
 
     # 6) check contracting combined leg versus contracting the individual legs
     if T.symmetry.has_trivial_braid:
@@ -1588,7 +1593,7 @@ def test_swap_gate_numpy(np_random):
     A = tensors.permute_legs(T, [1, 0], [3, 2])
     A_np = A.to_numpy(understood_braiding=True)
     expect = swap_gate_numpy.transpose(T_np, T.legs, [1, 0, 2, 3])
-    assert np.allclose(A_np, expect)
+    npt.assert_almost_equal(A_np, expect)
 
 
 @pytest.mark.parametrize(
@@ -1821,7 +1826,7 @@ def test_dagger(cls, cod, dom, make_compatible_tensor, np_random):
 
         if not T.symmetry.has_trivial_braid and cls is ChargedTensor:
             # TODO this should not be the case....?
-            assert np.allclose(res_np, expect) or np.allclose(res_np, -expect)
+            npt.assert_almost_equal(res_np, expect) or np.allclose(res_np, -expect)
         else:
             npt.assert_almost_equal(res_np, expect)
 
@@ -2162,7 +2167,7 @@ def test_horizontal_factorization(trunc, make_compatible_tensor, compatible_symm
         )
         # [*J1, *J2, *J2_rev, *K1_rev] = [*J, *J_rev]
         T_np = T.to_numpy(understood_braiding=True)
-        npt.assert_array_almost_equal(T2_np, T_np)
+        npt.assert_almost_equal(T2_np, T_np)
 
     A_bent = tensors.permute_legs(A, [*range(cod_cut + 1, A.num_legs), *range(cod_cut)], [cod_cut], bend_right=False)
     B_bent = tensors.permute_legs(B, [0], [*reversed(range(1, B.num_legs))], bend_right=True)
@@ -2363,7 +2368,7 @@ def test_linear_combination(cls, make_compatible_tensor):
         res.test_sanity()
         if compare_numpy:
             expect = valid_scalar * v_np + 2 * valid_scalar * w_np
-            npt.assert_allclose(res.to_numpy(understood_braiding=True), expect)
+            npt.assert_almost_equal(res.to_numpy(understood_braiding=True), expect)
         if valid_scalar == 0:
             continue
         # res = a * v + 2 * a * w  =>  v = res / a - 2 * w
@@ -2445,7 +2450,7 @@ def test_move_leg(cls, cod, dom, leg, codomain_pos, domain_pos, levels, make_com
         expect = swap_gate_numpy.permute_legs(
             T_np, T.num_codomain_legs, T.legs, codomain=codomain_perm, domain=domain_perm, bend_right=bend_right
         )
-        npt.assert_allclose(res_np, expect, atol=1.0e-14)
+        npt.assert_almost_equal(res_np, expect, decimal=14)
 
 
 def test_left_bends_fermions(block_backend, np_random):
@@ -2918,7 +2923,7 @@ def test_permute_legs(
             domain=domain,
             bend_right=bend_right,
         )
-        npt.assert_allclose(actual, expect, atol=1.0e-14)
+        npt.assert_almost_equal(actual, expect, decimal=14)
 
     # construct the instructions needed to undo the original instructions
     leg_perm = [*codomain, *reversed(domain)]
@@ -2989,7 +2994,7 @@ def test_scalar_multiply(cls, make_compatible_tensor):
             res = tensors.scalar_multiply(valid_scalar, T)
         res.test_sanity()
         if compare_numpy:
-            npt.assert_allclose(res.to_numpy(understood_braiding=True), valid_scalar * T_np)
+            npt.assert_almost_equal(res.to_numpy(understood_braiding=True), valid_scalar * T_np)
     for invalid_scalar in [None, (1, 2), T, 'abc']:
         with pytest.raises(TypeError, match='unsupported scalar type'):
             _ = tensors.scalar_multiply(invalid_scalar, T)
@@ -3058,7 +3063,7 @@ def test_scale_axis(cls, codom, dom, which_leg, make_compatible_tensor, np_rando
         expect = np.swapaxes(T_np, which_leg, -1)  # swap axis to be scaled to the back
         expect = expect * D.diagonal_as_numpy()  # broadcasts to last axis of expect
         expect = np.swapaxes(expect, which_leg, -1)  # swap back
-        npt.assert_allclose(res.to_numpy(understood_braiding=True), expect, atol=1.0e-14)
+        npt.assert_almost_equal(res.to_numpy(understood_braiding=True), expect, decimal=14)
 
 
 def test_squeeze_legs(make_compatible_tensor, compatible_symmetry):
@@ -3083,9 +3088,9 @@ def test_squeeze_legs(make_compatible_tensor, compatible_symmetry):
         expect_all = T_np[:, 0, 0, :, 0, :, :]
         expect_1 = T_np[:, 0]
         expect_2 = T_np[:, 0, :, :, 0]
-        npt.assert_allclose(res_all.to_numpy(understood_braiding=True), expect_all)
-        npt.assert_allclose(res_1.to_numpy(understood_braiding=True), expect_1)
-        npt.assert_allclose(res_2.to_numpy(understood_braiding=True), expect_2)
+        npt.assert_almost_equal(res_all.to_numpy(understood_braiding=True), expect_all)
+        npt.assert_almost_equal(res_1.to_numpy(understood_braiding=True), expect_1)
+        npt.assert_almost_equal(res_2.to_numpy(understood_braiding=True), expect_2)
     else:
         return  # TODO  Need to re-design checks, cant use .to_numpy() etc
 
@@ -3407,7 +3412,7 @@ def test_tdot(
             A2 = swap_gate_numpy.permute_legs(A_np, A.num_codomain_legs, A.legs, codomain=contr_A, bend_right=True)
             B2 = swap_gate_numpy.permute_legs(B_np, B.num_codomain_legs, B.legs, domain=contr_B, bend_right=True)
             expect = np.tensordot(A2, B2, ([*range(num_contr)], [*reversed(range(B.num_legs - num_contr, B.num_legs))]))
-        npt.assert_allclose(res_np, expect, atol=1.0e-14)
+        npt.assert_almost_equal(res_np, expect, decimal=12)
 
 
 @pytest.mark.parametrize(

--- a/tests/python_tests/test_trees.py
+++ b/tests/python_tests/test_trees.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from numpy import testing as npt
 
 from cyten.backends import get_backend
 from cyten.block_backends import Block
@@ -108,15 +109,15 @@ def test_FusionTree_braid(overbraid, j, any_symmetry, make_any_sectors, np_rando
     )
     braided1 = list(tree.braid(j, overbraid=overbraid).items())
     for t, _ in braided1:
-        assert np.all(t.uncoupled[:j] == tree.uncoupled[:j])
-        assert np.all(t.uncoupled[j] == tree.uncoupled[j + 1])
-        assert np.all(t.uncoupled[j + 1] == tree.uncoupled[j])
-        assert np.all(t.uncoupled[j + 2 :] == tree.uncoupled[j + 2 :])
+        npt.assert_array_equal(t.uncoupled[:j], tree.uncoupled[:j])
+        npt.assert_array_equal(t.uncoupled[j], tree.uncoupled[j + 1])
+        npt.assert_array_equal(t.uncoupled[j + 1], tree.uncoupled[j])
+        npt.assert_array_equal(t.uncoupled[j + 2 :], tree.uncoupled[j + 2 :])
         #
-        assert np.all(t.are_dual[:j] == tree.are_dual[:j])
+        npt.assert_array_equal(t.are_dual[:j], tree.are_dual[:j])
         assert t.are_dual[j] == tree.are_dual[j + 1]
         assert t.are_dual[j + 1] == tree.are_dual[j]
-        assert np.all(t.are_dual[j + 2 :] == tree.are_dual[j + 2 :])
+        npt.assert_array_equal(t.are_dual[j + 2 :], tree.are_dual[j + 2 :])
         #
         t.test_sanity()
 
@@ -129,7 +130,7 @@ def test_FusionTree_braid(overbraid, j, any_symmetry, make_any_sectors, np_rando
             expect, [*range(j), -2, -1, *range(j, num_uncoupled - 1)]
         )  # [a1 ... aj-1 aj+2 ... aj c aj+1 aj]
         res = sum(a * t.to_dense_block(understood_braiding=True) for t, a in braided1)
-        assert np.allclose(res, expect)
+        npt.assert_almost_equal(res, expect)
 
     # check if opposite braid undoes it
     res = {}
@@ -138,7 +139,7 @@ def test_FusionTree_braid(overbraid, j, any_symmetry, make_any_sectors, np_rando
             res[t_out] = res.get(t_out, 0) + a * b
     assert tree in res
     for t, a in res.items():
-        assert np.allclose(a, 1 if t == tree else 0)
+        npt.assert_almost_equal(a, 1 if t == tree else 0)
 
     # check yang baxter
     #   \   /   |          |   \   /
@@ -176,7 +177,7 @@ def test_FusionTree_braid(overbraid, j, any_symmetry, make_any_sectors, np_rando
     assert lhs.keys() == rhs.keys()
     for t, a_lhs in lhs.items():
         a_rhs = rhs[t]
-        assert np.allclose(a_lhs, a_rhs)
+        npt.assert_almost_equal(a_lhs, a_rhs)
 
 
 def tree_pair_to_numpy(X: trees.FusionTree, Y: trees.FusionTree):
@@ -202,22 +203,22 @@ def test_FusionTree_bend_leg(bend_down, any_symmetry, make_any_sectors, np_rando
     for (X_i, Y_i), _ in res:
         X_i.test_sanity()
         Y_i.test_sanity()
-        assert np.all(X_i.coupled == Y_i.coupled)
+        npt.assert_array_equal(X_i.coupled, Y_i.coupled)
         if bend_down:
-            assert np.all(X_i.uncoupled[:-1] == X.uncoupled)
-            assert np.all(Y_i.uncoupled == Y.uncoupled[:-1])
-            assert np.all(X_i.uncoupled[-1] == any_symmetry.dual_sector(Y.uncoupled[-1]))
+            npt.assert_array_equal(X_i.uncoupled[:-1], X.uncoupled)
+            npt.assert_array_equal(Y_i.uncoupled, Y.uncoupled[:-1])
+            npt.assert_array_equal(X_i.uncoupled[-1], any_symmetry.dual_sector(Y.uncoupled[-1]))
         else:
-            assert np.all(X_i.uncoupled == X.uncoupled[:-1])
-            assert np.all(Y_i.uncoupled[:-1] == Y.uncoupled)
-            assert np.all(Y_i.uncoupled[-1] == any_symmetry.dual_sector(X.uncoupled[-1]))
+            npt.assert_array_equal(X_i.uncoupled, X.uncoupled[:-1])
+            npt.assert_array_equal(Y_i.uncoupled[:-1], Y.uncoupled)
+            npt.assert_array_equal(Y_i.uncoupled[-1], any_symmetry.dual_sector(X.uncoupled[-1]))
 
     # compare to matrix representation
     if any_symmetry.can_be_dropped:
         # bending leg does nothing in this case
         expect = tree_pair_to_numpy(X, Y)
         res_np = sum(a_i * tree_pair_to_numpy(X_i, Y_i) for (X_i, Y_i), a_i in res)
-        assert np.allclose(res_np, expect)
+        npt.assert_almost_equal(res_np, expect)
 
     # check that bending back gives back the same tree
     res2 = {}
@@ -226,7 +227,7 @@ def test_FusionTree_bend_leg(bend_down, any_symmetry, make_any_sectors, np_rando
             res2[Y2_i, X2_i] = res2.get((Y2_i, X2_i), 0) + a_i * b_i
     assert (X, Y) in res2
     for pair, a in res2.items():
-        assert np.allclose(a, 1 if pair == (X, Y) else 0)
+        npt.assert_almost_equal(a, 1 if pair == (X, Y) else 0)
 
     # TODO is there anything else we can check at this level...?
 
@@ -261,18 +262,18 @@ def test_FusionTree_manipulations(compatible_symmetry, compatible_backend, make_
         split_sector = tree.inner_sectors[n_split - 2]
 
         # test left tree
-        assert np.all(left_tree.uncoupled == tree.uncoupled[:n_split])
-        assert np.all(left_tree.are_dual == tree.are_dual[:n_split])
-        assert np.all(left_tree.inner_sectors == tree.inner_sectors[: n_split - 2])
-        assert np.all(left_tree.coupled == split_sector)
-        assert np.all(left_tree.multiplicities == tree.multiplicities[: n_split - 1])
+        npt.assert_array_equal(left_tree.uncoupled, tree.uncoupled[:n_split])
+        npt.assert_array_equal(left_tree.are_dual, tree.are_dual[:n_split])
+        npt.assert_array_equal(left_tree.inner_sectors, tree.inner_sectors[: n_split - 2])
+        npt.assert_array_equal(left_tree.coupled, split_sector)
+        npt.assert_array_equal(left_tree.multiplicities, tree.multiplicities[: n_split - 1])
 
         # test right tree
-        assert np.all(right_tree.uncoupled == np.vstack((split_sector, tree.uncoupled[n_split:])))
-        assert np.all(right_tree.are_dual == np.append([False], tree.are_dual[n_split:]))
-        assert np.all(right_tree.inner_sectors == tree.inner_sectors[n_split - 1 :])
-        assert np.all(right_tree.coupled == tree.coupled)
-        assert np.all(right_tree.multiplicities == tree.multiplicities[n_split - 1 :])
+        npt.assert_array_equal(right_tree.uncoupled, np.vstack((split_sector, tree.uncoupled[n_split:])))
+        npt.assert_array_equal(right_tree.are_dual, np.append([False], tree.are_dual[n_split:]))
+        npt.assert_array_equal(right_tree.inner_sectors, tree.inner_sectors[n_split - 1 :])
+        npt.assert_array_equal(right_tree.coupled, tree.coupled)
+        npt.assert_array_equal(right_tree.multiplicities, tree.multiplicities[n_split - 1 :])
 
         # test insert
         assert tree == right_tree.insert(left_tree)
@@ -337,14 +338,14 @@ def check_insert_at_via_f_symbols(tree1: trees.FusionTree, tree2: trees.FusionTr
     norm = 0
     for tree, amp in combined_tree.items():
         tree.test_sanity()
-        assert np.all(tree.uncoupled == uncoupled)
-        assert np.all(tree.are_dual == are_dual)
-        assert np.all(tree.coupled == coupled)
-        assert np.all(tree.multiplicities[i + tree2.num_vertices :] == tree1.multiplicities[i:])
+        npt.assert_array_equal(tree.uncoupled, uncoupled)
+        npt.assert_array_equal(tree.are_dual, are_dual)
+        npt.assert_array_equal(tree.coupled, coupled)
+        npt.assert_array_equal(tree.multiplicities[i + tree2.num_vertices :], tree1.multiplicities[i:])
         if i > 0:
-            assert np.all(tree.inner_sectors[i - 1 + tree2.num_vertices :] == tree1.inner_sectors[i - 1 :])
-            assert np.all(tree.inner_sectors[: i - 1] == tree1.inner_sectors[: i - 1])
-            assert np.all(tree.multiplicities[: i - 1] == tree1.multiplicities[: i - 1])
+            npt.assert_array_equal(tree.inner_sectors[i - 1 + tree2.num_vertices :], tree1.inner_sectors[i - 1 :])
+            npt.assert_array_equal(tree.inner_sectors[: i - 1], tree1.inner_sectors[: i - 1])
+            npt.assert_array_equal(tree.multiplicities[: i - 1], tree1.multiplicities[: i - 1])
 
         if i == 0 or tree2.num_uncoupled == 1:
             fs = 1  # no F symbols to apply
@@ -370,9 +371,9 @@ def check_insert_at_via_f_symbols(tree1: trees.FusionTree, tree2: trees.FusionTr
                 mu = tree2.multiplicities[j + 1]
                 fs = np.tensordot(fs, f[mu, :, :, lam], [0, 1])
             fs = fs[nu]
-        assert np.isclose(fs, amp)
+        npt.assert_almost_equal(fs, amp)
         norm += amp * np.conj(amp)
-    assert np.isclose(norm, 1)
+    npt.assert_almost_equal(norm, 1)
 
 
 def check_outer_via_f_symbols(tree1: trees.FusionTree, tree2: trees.FusionTree):
@@ -388,11 +389,11 @@ def check_outer_via_f_symbols(tree1: trees.FusionTree, tree2: trees.FusionTree):
     norm = 0
     for tree, amp in combined_tree.items():
         tree.test_sanity()
-        assert np.all(tree.uncoupled == uncoupled)
-        assert np.all(tree.are_dual == are_dual)
-        assert np.all(tree.inner_sectors[: tree1.num_inner_edges] == tree1.inner_sectors)
-        assert np.all(tree.inner_sectors[tree1.num_inner_edges] == tree1.coupled)
-        assert np.all(tree.multiplicities[: tree1.num_inner_edges] == tree1.multiplicities[:-1])
+        npt.assert_array_equal(tree.uncoupled, uncoupled)
+        npt.assert_array_equal(tree.are_dual, are_dual)
+        npt.assert_array_equal(tree.inner_sectors[: tree1.num_inner_edges], tree1.inner_sectors)
+        npt.assert_array_equal(tree.inner_sectors[tree1.num_inner_edges], tree1.coupled)
+        npt.assert_array_equal(tree.multiplicities[: tree1.num_inner_edges], tree1.multiplicities[:-1])
 
         if tree1.num_uncoupled == 0 or tree2.num_uncoupled <= 1:
             fs = 1
@@ -424,9 +425,9 @@ def check_outer_via_f_symbols(tree1: trees.FusionTree, tree2: trees.FusionTree):
             # two coupled sectors fuse -> sum them as we allow all multiplicities
             fs = np.sum(fs[:])
 
-        assert np.isclose(fs, amp)
+        npt.assert_almost_equal(fs, amp)
         norm += amp * np.conj(amp)
-    assert np.isclose(norm, norm_expect)
+    npt.assert_almost_equal(norm, norm_expect)
 
 
 def random_trees_from_uncoupled(symmetry, uncoupled, np_random, are_dual=None) -> list[trees.FusionTree]:
@@ -460,7 +461,7 @@ def check_fusion_trees(it: trees.fusion_trees, expect_len: int = None):
 
     num_trees = 0
     for tree in it:
-        assert np.all(tree.are_dual == it.are_dual)
+        npt.assert_array_equal(tree.are_dual, it.are_dual)
         tree.test_sanity()
         assert it.index(tree) == num_trees
         num_trees += 1

--- a/tests/python_tests/tools/test_tools.py
+++ b/tests/python_tests/tools/test_tools.py
@@ -117,7 +117,7 @@ def test_make_grid(cstyle, shape):
     # order
     should_be_sorted = grid[:, ::-1] if cstyle else grid
     perm = np.lexsort(should_be_sorted.T)
-    assert np.all(perm == np.arange(len(perm)))
+    npt.assert_array_equal(perm, np.arange(len(perm)))
     # contains all entries
     #    if we have prod(shape) many valid combinations, we have all of them
     assert len(np.unique(grid, axis=0)) == len(grid)


### PR DESCRIPTION
Consistently use ``numpy.testing.assert_array_equal`` for exact equality or ``numpy.testing.assert_almost_equal`` for equality with tolerance, with a few excpetions using ``assert_almost_equal_nulp`` for a very slim tolerance.

Fixes #98