### PR TITLE
Site.multiply_operators and trivial_shift in symmetries

### DIFF
--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -82,7 +82,10 @@ class Site:
         self.default_device = default_device
         self.onsite_operators: dict[str, SymmetricTensor] = {}
         self.add_onsite_operator(
-            'Id', Identity(leg=self.leg, backend=self.backend, device=self.default_device, labels=['p', 'p*'])
+            'Id',
+            Identity(
+                leg=self.leg, backend=self.backend, device=self.default_device, labels=['p', 'p*']
+            ).as_DiagonalTensor(),
         )
         if onsite_operators is not None:
             for name, op in onsite_operators.items():

--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -29,7 +29,7 @@ from ..symmetries import (
     SymmetryError,
     SymmetryFactor,
 )
-from ..tensors import DiagonalTensor, SymmetricTensor
+from ..tensors import DiagonalTensor, Identity, SymmetricTensor, compose
 from ..tools import as_immutable_array, is_iterable, to_iterable, to_valid_idx
 
 ALL_SPECIES = object()
@@ -81,6 +81,9 @@ class Site:
             default_device = 'cpu'
         self.default_device = default_device
         self.onsite_operators: dict[str, SymmetricTensor] = {}
+        self.add_onsite_operator(
+            'Id', Identity(leg=self.leg, backend=self.backend, device=self.default_device, labels=['p', 'p*'])
+        )
         if onsite_operators is not None:
             for name, op in onsite_operators.items():
                 # we add them one-by-one instead to perform the input checks and conversions
@@ -118,7 +121,9 @@ class Site:
         """Add an operator to the :attr:`onsite_operators`."""
         if name in self.onsite_operators:
             raise ValueError(f'Operator with {name=} already exists.')
-        #
+        if ' ' in name:
+            # not allowed as it signifies multiplication of onsite operators
+            raise ValueError('operator names are not allowed to feature whitespace')
         if isinstance(op, SymmetricTensor):
             if is_diagonal is not None:
                 assert isinstance(op, DiagonalTensor) == bool(is_diagonal)
@@ -147,6 +152,89 @@ class Site:
                 understood_braiding=understood_braiding,
             )
         self.onsite_operators[name] = op
+
+    def get_op(self, name: str) -> SymmetricTensor:
+        """Return operator of given name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the operator to be returned.
+            In case of multiple operator names separated by whitespace,
+            we multiply them together to a single on-site operator
+            (with the one on the right acting first).
+
+        Returns
+        -------
+        op : :class:`~cyten.SymmetricTensor`
+            The operator given by `name`, with labels ``'p', 'p*'``.
+            If name already was an onsite operator, it's directly returned.
+
+        """
+        names = name.split()
+        if names[0] in self.onsite_operators:
+            op = self.onsite_operators[names[0]]
+        else:
+            raise ValueError(f"{self!r} doesn't have the operator {names[0]!r}")
+        for name2 in names[1:]:
+            if name2 in self.onsite_operators:
+                op2 = self.onsite_operators[name2]
+            else:
+                raise ValueError(f"{self!r} doesn't have the operator {name2!r}")
+            op = compose(op, op2)
+        return op
+
+    def multiply_op_names(self, names: list[str]) -> str:
+        """Multiply operator names together.
+
+        Join the operator names in `names` such that `get_op` returns the product of the
+        corresponding operators.
+
+        Parameters
+        ----------
+        names : list of str
+            List of valid operator labels.
+
+        Returns
+        -------
+        combined_opname : str
+            A valid operator name
+            Operator name representing the product of operators in `names`.
+
+        """
+        if len(names) == 0:
+            return 'Id'
+        return ' '.join(names)
+
+    def multiply_operators(self, operators: list[str | SymmetricTensor]) -> SymmetricTensor:
+        """Multiply local operators (possibly given by their names) together.
+
+        Parameters
+        ----------
+        operators : list of {str | :class:`~cyten.SymmetricTensor`}
+            List of valid operator names (to be translated with :meth:`get_op`) or
+            directly on-site operators in the form of tensors with ``'p', 'p*'`` labels.
+            The operators are multiplied left-to-right.
+
+        Returns
+        -------
+        combined_operator : :class:`~cyten.SymmetricTensor`
+            The product of the given `operators` in a left-to-right multiplication following the
+            usual mathematical convention. For example, if ``operators=['Sz', 'Sp', 'Sx']``,
+            the final operator is equivalent to ``site.get_op('Sz Sp Sx')``, with the ``'Sx'``
+            operator acting first on any physical state.
+
+        """
+        if len(operators) == 0:
+            return self.onsite_operators['Id']
+        op = operators[0]
+        if isinstance(op, str):
+            op = self.get_op(op)
+        for next_op in operators[1:]:
+            if isinstance(next_op, str):
+                next_op = self.get_op(next_op)
+            op = compose(op, next_op)
+        return op
 
     def state_index(self, label: str | int) -> int:
         """The index of a basis state."""

--- a/cyten/symmetries/_symmetries.py
+++ b/cyten/symmetries/_symmetries.py
@@ -112,6 +112,7 @@ class BaseSymmetry(metaclass=ABCMeta):
         trivial_sector: Sector,
         num_sectors: int | float,
         has_complex_topological_data: bool,
+        trivial_shift: bool,
     ):
         self.fusion_style = fusion_style
         self.braiding_style = braiding_style
@@ -120,6 +121,7 @@ class BaseSymmetry(metaclass=ABCMeta):
         self.sector_ind_len = sector_ind_len = len(trivial_sector)
         self.empty_sector_array = as_immutable_array(np.zeros((0, sector_ind_len), dtype=int))
         self.has_complex_topological_data = has_complex_topological_data
+        self.trivial_shift = trivial_shift
 
     # ABSTRACT METHODS
 
@@ -700,6 +702,7 @@ class Symmetry(BaseSymmetry):
             trivial_sector=np.concatenate([f.trivial_sector for f in flat_factors]),
             num_sectors=math.prod([symm.num_sectors for symm in flat_factors]),
             has_complex_topological_data=any(f.has_complex_topological_data for f in flat_factors),
+            trivial_shift=all(f.trivial_shift for f in flat_factors),
         )
         dtypes = [f.fusion_tensor_dtype for f in flat_factors]
         if None in dtypes:
@@ -1051,6 +1054,9 @@ class SymmetryFactor(BaseSymmetry):
         since real blocks become complex under leg manipulations.
         Note: for a group (and for fermions), the topo data must be real if the fusion tensors
         are real. This is because the associator, the braid, and the cup are all real for groups.
+    trivial_shift : bool
+        Whether or not the symmetry sectors transform trivially under spatial translations.
+        Nontrivial shifts are only sensible for symmetries with unique fusion style.
 
     Notes
     -----
@@ -1089,6 +1095,7 @@ class SymmetryFactor(BaseSymmetry):
         num_sectors: int | float,
         has_complex_topological_data: bool,
         descriptive_name: str | None = None,
+        trivial_shift: bool = True,
     ):
         self.descriptive_name = descriptive_name
         self.group_name = group_name
@@ -1099,6 +1106,7 @@ class SymmetryFactor(BaseSymmetry):
             trivial_sector=trivial_sector,
             num_sectors=num_sectors,
             has_complex_topological_data=has_complex_topological_data,
+            trivial_shift=trivial_shift,
         )
 
     # ABSTRACT METHODS
@@ -1207,6 +1215,7 @@ class Group(SymmetryFactor):
         num_sectors: int | float,
         has_complex_topological_data: bool,
         descriptive_name: str | None = None,
+        trivial_shift: bool = True,
     ):
         SymmetryFactor.__init__(
             self,
@@ -1217,6 +1226,7 @@ class Group(SymmetryFactor):
             num_sectors=num_sectors,
             has_complex_topological_data=has_complex_topological_data,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     @abstractmethod
@@ -1244,7 +1254,12 @@ class AbelianGroup(Group):
     fusion_tensor_dtype = Dtype.float64
 
     def __init__(
-        self, trivial_sector: Sector, group_name: str, num_sectors: int | float, descriptive_name: str | None = None
+        self,
+        trivial_sector: Sector,
+        group_name: str,
+        num_sectors: int | float,
+        descriptive_name: str | None = None,
+        trivial_shift: bool = True,
     ):
         Group.__init__(
             self,
@@ -1254,6 +1269,7 @@ class AbelianGroup(Group):
             num_sectors=num_sectors,
             has_complex_topological_data=False,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     def sector_str(self, a: Sector) -> str:
@@ -1358,13 +1374,14 @@ class U1(AbelianGroup):
     ..., `[-2]`, `[-1]`, `[0]`, `[1]`, `[2]`, ...
     """
 
-    def __init__(self, descriptive_name: str | None = None):
+    def __init__(self, descriptive_name: str | None = None, trivial_shift: bool = True):
         AbelianGroup.__init__(
             self,
             trivial_sector=np.array([0], dtype=int),
             group_name='U(1)',
             num_sectors=np.inf,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     def is_valid_sector(self, a: Sector) -> bool:
@@ -1404,7 +1421,7 @@ class ZN(AbelianGroup):
     `[0]`, `[1]`, ..., `[N-1]`
     """
 
-    def __init__(self, N: int, descriptive_name: str | None = None):
+    def __init__(self, N: int, descriptive_name: str | None = None, trivial_shift: bool = True):
         assert isinstance(N, int)
         if not isinstance(N, int) and N > 1:
             raise ValueError(f'invalid ZNSymmetry(N={N!r},{descriptive_name!s})')
@@ -1429,6 +1446,7 @@ class ZN(AbelianGroup):
             group_name=group_name,
             num_sectors=N,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     def __repr__(self):
@@ -2154,7 +2172,7 @@ class FermionNumber(SymmetryFactor):
 
     fusion_tensor_dtype = Dtype.float64
 
-    def __init__(self, descriptive_name: str = None):
+    def __init__(self, descriptive_name: str = None, trivial_shift: bool = True):
         super().__init__(
             fusion_style=FusionStyle.single,
             braiding_style=BraidingStyle.fermionic,
@@ -2163,6 +2181,7 @@ class FermionNumber(SymmetryFactor):
             num_sectors=np.inf,
             has_complex_topological_data=False,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     def is_valid_sector(self, a: Sector) -> bool:
@@ -2273,7 +2292,7 @@ class FermionParity(SymmetryFactor):
     even = as_immutable_array(np.array([0], dtype=int))
     odd = as_immutable_array(np.array([1], dtype=int))
 
-    def __init__(self, descriptive_name: str = None):
+    def __init__(self, descriptive_name: str = None, trivial_shift: bool = True):
         SymmetryFactor.__init__(
             self,
             fusion_style=FusionStyle.single,
@@ -2283,6 +2302,7 @@ class FermionParity(SymmetryFactor):
             num_sectors=2,
             has_complex_topological_data=False,
             descriptive_name=descriptive_name,
+            trivial_shift=trivial_shift,
         )
 
     def is_valid_sector(self, a: Sector) -> bool:

--- a/tests/python_tests/models/test_site.py
+++ b/tests/python_tests/models/test_site.py
@@ -56,10 +56,10 @@ def test_site(np_random, block_backend, symmetry_backend, use_sym):
     site = degrees_of_freedom.Site(leg, backend=backend, state_labels=labels)
     assert site.state_index('x10') == 0
     assert site.state_index('x17') == 7
-    assert set(site.onsite_operators.keys()) == set()
+    assert set(site.onsite_operators.keys()) == set(('Id',))
     op1 = cyten.SymmetricTensor.from_random_uniform([leg], [leg], backend=backend, labels=['p', 'p*'])
     site.add_onsite_operator('silly_op', op1)
-    assert set(site.onsite_operators.keys()) == {'silly_op'}
+    assert set(site.onsite_operators.keys()) == {'Id', 'silly_op'}
     assert site.onsite_operators['silly_op'] is op1
 
     op2 = cyten.SymmetricTensor.from_random_uniform([leg], [leg], backend=backend, labels=['p', 'p*'])
@@ -70,6 +70,14 @@ def test_site(np_random, block_backend, symmetry_backend, use_sym):
     site.add_onsite_operator('op3', op3_dense, is_diagonal=True)
     assert isinstance(site.onsite_operators['op3'], cyten.DiagonalTensor)
     npt.assert_equal(site.onsite_operators['op3'].to_numpy(), op3_dense)
+
+    # test get_op and multiplication of operators
+    # the correct order of multiplication is checked using the spin algebra in test_spin_site
+    assert cyten.almost_equal(site.get_op('silly_op'), site.onsite_operators['silly_op'])
+    combinations = [['silly_op', 'op2'], ['silly_op', 'op3', 'op2'], []]
+    for ops in combinations:
+        ops_name = site.multiply_op_names(ops)
+        assert cyten.almost_equal(site.multiply_operators(ops), site.get_op(ops_name))
 
     # if use_sym:
     #     leg2 = leg.drop_symmetry(1)
@@ -107,13 +115,27 @@ def test_spin_site(any_backend, spin):
         npt.assert_almost_equal(sz[down, down], -1 * spin)
         npt.assert_almost_equal(sz[up, up], spin)
 
-        expect_ops = {}
+        expect_ops = {'Id': True}
         if conserve in ['Sz', 'parity', 'None']:
             expect_ops.update(Sz=True)
             if site.double_total_spin == 1:
                 expect_ops.update(Sigmaz=True)
         if conserve in ['None']:
             expect_ops.update(Sx=False, Sy=False, Sp=False, Sm=False)
+
+            # test onsite multiplication with spin algebra
+            # [Sx, Sy] = i*Sz
+            assert cyten.almost_equal(
+                site.get_op('Sx Sy') - site.get_op('Sy Sx'), 1j * site.get_op('Sz').as_SymmetricTensor()
+            )
+            # [Sy, Sz] = i*Sx
+            assert cyten.almost_equal(site.get_op('Sy Sz') - site.get_op('Sz Sy Id'), 1j * site.get_op('Sx'))
+            # -i * Sz * [Sx, Sy] = Sz Sz
+            assert cyten.almost_equal(
+                -1j * site.get_op('Sz Id Sx Sy') + 1j * site.get_op('Sz Sy Sx'),
+                site.get_op('Sz Sz').as_SymmetricTensor(),
+            )
+
             if site.double_total_spin == 1:
                 expect_ops.update(Sigmax=False, Sigmay=False)
         check_operator_availability(site, expect_ops)
@@ -143,7 +165,7 @@ def test_spinless_boson_site(any_backend, np_random, Nmax):
             state = site.state_labels[str(i)]
             npt.assert_almost_equal(site.n_tot[state, state], i)
 
-        expect_ops = dict(N0=True, N=True, Ntot=True)
+        expect_ops = dict(Id=True, N0=True, N=True, Ntot=True)
         expect_ops.update(N0N0=True, NN=True, NtotNtot=True)
         expect_ops.update(P0=True, P=True, Ptot=True)
         if filling is not None:
@@ -186,7 +208,7 @@ def test_spinless_boson_site(any_backend, np_random, Nmax):
                 npt.assert_almost_equal(site.number_operators[state, state, 0], i)
                 npt.assert_almost_equal(site.number_operators[state, state, 1], j)
 
-        expect_ops = dict(N0=True, N1=True, Ntot=True)
+        expect_ops = dict(Id=True, N0=True, N1=True, Ntot=True)
         expect_ops.update(N0N0=True, N1N1=True, NtotNtot=True)
         expect_ops.update(P0=True, P1=True, Ptot=True)
         if filling is not None:
@@ -223,7 +245,7 @@ def test_spinless_fermion_site(block_backend, np_random, num_species):
                     npt.assert_almost_equal(site.number_operators[state, state, k], occupations[k])
 
         expect_ops = {f'N{k}': True for k in range(num_species)}
-        expect_ops.update(Ntot=True, Ptot=True, NtotNtot=True)
+        expect_ops.update(Id=True, Ntot=True, Ptot=True, NtotNtot=True)
         if num_species == 1:
             expect_ops.update(N=True)
         if filling is not None:
@@ -259,7 +281,7 @@ def test_spin_half_fermion_site(block_backend, np_random):
             npt.assert_almost_equal(site.number_operators[state, state, 1], occupations[1])  # spin down
             npt.assert_almost_equal(site.spin_vector[state, state, 2], 0.5 * (occupations[0] - occupations[1]))
 
-        expect_ops = dict(Ntot=True, Ptot=True, NtotNtot=True)
+        expect_ops = dict(Id=True, Ntot=True, Ptot=True, NtotNtot=True)
         if conserve_S in ['Sz', 'parity', 'None']:
             expect_ops.update(Nup=True, Ndown=True)
             expect_ops.update(Sz=True, Sigmaz=True)
@@ -301,7 +323,7 @@ def test_clock_site(any_backend, q):
         else:
             assert 'down' not in site.state_labels
 
-        expect_ops = dict(Z=True, Zhc=True, Zphc=True)
+        expect_ops = dict(Id=True, Z=True, Zhc=True, Zphc=True)
         if conserve == 'None':
             expect_ops.update(X=False, Xhc=False, Xphc=False)
         check_operator_availability(site, expect_ops)


### PR DESCRIPTION
Add `Site.multiply_operators` and `Site.get_op` for multiplying onsite operators more conveniently (as in TeNPy v1)

Further add the attribute `trivial_shift` to all symmetries to replace `chinfo.trivial_shift` of TeNPy v1.