### PR TITLE
Add as_dtype

### DIFF
--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -83,9 +83,7 @@ class Site:
         self.onsite_operators: dict[str, SymmetricTensor] = {}
         self.add_onsite_operator(
             'Id',
-            Identity(
-                leg=self.leg, backend=self.backend, device=self.default_device, labels=['p', 'p*']
-            ).as_DiagonalTensor(),
+            Identity(leg=self.leg, backend=self.backend, device=self.default_device, labels=['p', 'p*']),
         )
         if onsite_operators is not None:
             for name, op in onsite_operators.items():

--- a/cyten/tensors/_tensors.py
+++ b/cyten/tensors/_tensors.py
@@ -471,6 +471,18 @@ class Tensor(LabelledLegs, metaclass=ABCMeta):
         )
 
     @abstractmethod
+    def as_dtype(self, dtype: Dtype) -> Tensor:
+        """Convert to a tensor of the given dtype on the same device.
+
+        Parameters
+        ----------
+        dtype: Dtype
+            The dtype of the result.
+
+        """
+        ...
+
+    @abstractmethod
     def as_SymmetricTensor(self, guarantee_copy: bool = False, warning: str = None) -> SymmetricTensor:
         """Convert to a :class:`SymmetricTensor`, if possible.
 
@@ -487,7 +499,7 @@ class Tensor(LabelledLegs, metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def copy(self, deep=True, device: str = None) -> Tensor:
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> Tensor:
         """Copy the tensor.
 
         Parameters
@@ -496,6 +508,8 @@ class Tensor(LabelledLegs, metaclass=ABCMeta):
             If the copy should be deep. A shallow copy is a new instance with the same data.
         device: str, optional
             The device for the result. Per default, use the same device as `self`.
+        dtype: Dtype, optional
+            The dtype of the result. Per default, use the same dtype as `self`.
 
         """
         ...
@@ -1422,13 +1436,24 @@ class SymmetricTensor(Tensor):
                 raise ValueError(f'SymmetricTensor with {symmetry} must have complex dtype')
         return dtype
 
+    def as_dtype(self, dtype: Dtype) -> SymmetricTensor:
+        if dtype == self.dtype:
+            return self
+        return SymmetricTensor(
+            self.backend.to_dtype(self, dtype), self.codomain, self.domain, self.backend, self.labels
+        )
+
     def as_SymmetricTensor(self, guarantee_copy: bool = False, warning: str = None) -> SymmetricTensor:
         if guarantee_copy:
             return self.copy()
         return self
 
-    def copy(self, deep=True, device: str = None) -> SymmetricTensor:
-        if deep:
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> SymmetricTensor:
+        if dtype is not None and dtype != self.dtype:
+            if device is not None or device != self.device:
+                return self.as_dtype(dtype)
+            data = self.backend.move_to_device(self.as_dtype(dtype), device=device)
+        elif deep:
             data = self.backend.copy_data(self, device=device)
         elif device is not None:
             data = self.backend.move_to_device(self, device=device)
@@ -2055,6 +2080,11 @@ class DiagonalTensor(SymmetricTensor):
             raise ValueError(f'any is not defined for dtype {self.dtype}')
         return self.backend.diagonal_any(self)
 
+    def as_dtype(self, dtype: Dtype) -> DiagonalTensor:
+        if dtype == self.dtype:
+            return self
+        return DiagonalTensor(self.backend.to_dtype(self, dtype), self.leg, self.backend, self.labels)
+
     def as_DiagonalTensor(self, guarantee_copy=False, warning=None):
         if guarantee_copy:
             return self.copy()
@@ -2132,8 +2162,12 @@ class DiagonalTensor(SymmetricTensor):
             raise TypeError(msg)
         return DiagonalTensor(data, leg=self.leg, backend=self.backend, labels=labels)
 
-    def copy(self, deep=True, device: str = None) -> SymmetricTensor:
-        if deep:
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> DiagonalTensor:
+        if dtype is not None and dtype != self.dtype:
+            if device is not None or device != self.device:
+                return self.as_dtype(dtype)
+            data = self.backend.move_to_device(self.as_dtype(dtype), device=device)
+        elif deep:
             data = self.backend.copy_data(self)
         elif device is not None:
             data = self.backend.move_to_device(self, device=device)
@@ -2367,6 +2401,11 @@ class Identity(DiagonalTensor):
             raise ValueError(f'any is not defined for dtype {self.dtype}')
         return self.leg.dim > 0
 
+    def as_dtype(self, dtype: Dtype) -> Identity:
+        if dtype == self.dtype:
+            return self
+        return Identity(self.leg, self.backend, dtype, self.device, self.labels)
+
     def as_SymmetricTensor(self, guarantee_copy=False, warning=None):
         if warning is not None:
             warnings.warn(warning, UserWarning, stacklevel=2)
@@ -2387,7 +2426,9 @@ class Identity(DiagonalTensor):
             other, func=func, operand=operand, return_NotImplemented=return_NotImplemented, right=right
         )
 
-    def copy(self, deep=True, device=None):
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> Identity:
+        if dtype is not None and dtype != self.dtype:
+            return self.as_dtype(dtype, device=device)
         return self
 
     def diagonal(self):
@@ -2920,6 +2961,14 @@ class Mask(Tensor):
         res = self.as_block_mask()
         return self.backend.block_backend.to_numpy(res, numpy_dtype=bool)
 
+    def as_dtype(self, dtype: Dtype) -> Mask:
+        if dtype == self.dtype:
+            return self
+        raise ValueError(
+            'Mask requires Dtype.bool; use as_DiagonalTensor() or as_SymmetricTensor() '
+            'for conversion to other tensor classes'
+        )
+
     def as_DiagonalTensor(self, dtype=Dtype.complex128) -> DiagonalTensor:
         return DiagonalTensor(
             data=self.backend.mask_to_diagonal(self, dtype=dtype),
@@ -2989,8 +3038,12 @@ class Mask(Tensor):
             labels=_get_matching_labels(self.labels, other.labels),
         )
 
-    def copy(self, deep=True, device: str = None) -> Mask:
-        if deep:
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> Mask:
+        if dtype is not None and dtype != self.dtype:
+            if device is not None or device != self.device:
+                return self.as_dtype(dtype)
+            data = self.backend.move_to_device(self.as_dtype(dtype), device=device)
+        elif deep:
             data = self.backend.copy_data(self)
         elif device is not None:
             data = self.backend.move_to_device(self, device=device)
@@ -3521,6 +3574,11 @@ class ChargedTensor(Tensor):
         """If the :class:`ChargedTensor` concept is well defined for the `symmetry`."""
         return symmetry.has_symmetric_braid
 
+    def as_dtype(self, dtype: Dtype) -> ChargedTensor:
+        if dtype == self.dtype:
+            return self
+        return ChargedTensor(self.invariant_part.as_dtype(dtype), self.charged_state)
+
     def as_SymmetricTensor(self, guarantee_copy: bool = False, warning: str = None) -> SymmetricTensor:
         """Convert to symmetric tensor, if possible."""
         if warning is not None:
@@ -3545,14 +3603,14 @@ class ChargedTensor(Tensor):
         res = tdot(state, self.invariant_part, 0, -1)
         return bend_legs(res, num_codomain_legs=self.num_codomain_legs)
 
-    def copy(self, deep=True, device: str = None) -> ChargedTensor:
-        inv_part = self.invariant_part.copy(deep=deep, device=device)
+    def copy(self, deep: bool = True, device: str = None, dtype: Dtype = None) -> ChargedTensor:
+        inv_part = self.invariant_part.copy(deep=deep, device=device, dtype=dtype)
         charged_state = self.charged_state
         if charged_state is not None:
+            if (device is not None and not deep) or (dtype is not None and dtype != self.dtype):
+                charged_state = self.backend.block_backend.as_block(charged_state, device=device, dtype=dtype)
             if deep:
                 charged_state = self.backend.block_backend.copy_block(charged_state, device=device)
-            elif device is not None:
-                charged_state = self.backend.block_backend.as_block(charged_state, device=device)
         return ChargedTensor(inv_part, charged_state)
 
     def _get_item(self, idx: list[int]) -> bool | float | complex:

--- a/cyten/tensors/_tensors.py
+++ b/cyten/tensors/_tensors.py
@@ -2337,8 +2337,12 @@ class Identity(DiagonalTensor):
             dtype = Dtype.float64
         if device is None:
             device = backend.block_backend.default_device
-        Tensor.__init__(
-            self, codomain=codomain, domain=domain, backend=backend, labels=labels, dtype=dtype, device=device
+        # we give it dummy data here (that is not used in contractions etc.)
+        # this is important since there is a potential change in the device matching
+        # the same effect for the other tensor classes (happens e.g. for torch)
+        # using backend.block_backend.as_device() is not sufficient? Why?
+        DiagonalTensor.__init__(
+            self, backend.eye_data(codomain, dtype, device), leg=leg, backend=backend, labels=labels
         )
 
     def test_sanity(self):

--- a/cyten/tensors/_tensors.py
+++ b/cyten/tensors/_tensors.py
@@ -515,6 +515,22 @@ class Tensor(LabelledLegs, metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def to_backend(self, backend: TensorBackend, dtype: Dtype = None, device: str = None) -> Tensor:
+        """Convert to a tensor with a different backend.
+
+        Parameters
+        ----------
+        backend: TensorBackend
+            The backend of the result.
+        dtype: Dtype, optional
+            The dtype of the result. Per default, use the same dtype as `self`.
+        device: str, optional
+            The device for the result. Per default, use the same device as `self`.
+
+        """
+        ...
+
+    @abstractmethod
     def to_dense_block(
         self, leg_order: list[int | str] = None, dtype: Dtype = None, understood_braiding: bool = False
     ) -> Block:
@@ -1496,7 +1512,7 @@ class SymmetricTensor(Tensor):
             combine = []
             pipe_dualities = []
             flat_leg_counter = 0
-            for leg in conventional_leg_order(self):
+            for leg in self.legs:
                 if isinstance(leg, LegPipe):
                     combine.append([*range(flat_leg_counter, flat_leg_counter + leg.num_legs)])
                     pipe_dualities.append(leg.is_dual)
@@ -1518,7 +1534,7 @@ class SymmetricTensor(Tensor):
             new_data = backend.from_dense_block(new_block, codomain=self.codomain, domain=self.domain, tol=0)
         elif isinstance(backend, AbelianBackend):
             if isinstance(self.backend, AbelianBackend):
-                new_data = self.backend.to_block_backend(self.data, backend.block_backend)
+                new_data = self.backend.to_block_backend(self.data, backend.block_backend, dtype=dtype, device=device)
             elif isinstance(self.backend, FusionTreeBackend):
                 new_data = _convert_FT_to_abelian(self, backend, dtype=dtype, device=device)
             else:
@@ -1527,7 +1543,7 @@ class SymmetricTensor(Tensor):
             if isinstance(self.backend, AbelianBackend):
                 new_data = _convert_abelian_to_FT(self, backend, dtype=dtype, device=device)
             elif isinstance(self.backend, FusionTreeBackend):
-                new_data = self.backend.to_block_backend(self.data, backend.block_backend)
+                new_data = self.backend.to_block_backend(self.data, backend.block_backend, dtype=dtype, device=device)
             else:
                 raise RuntimeError
         else:
@@ -2262,7 +2278,7 @@ class DiagonalTensor(SymmetricTensor):
 
         device = backend.block_backend.as_device(self.device if device is None else device)
         if isinstance(self.backend, FusionTreeBackend) and isinstance(backend, FusionTreeBackend):
-            new_data = self.backend.to_block_backend(self.data, backend.block_backend)
+            new_data = self.backend.to_block_backend(self.data, backend.block_backend, dtype=dtype, device=device)
         else:
             old_diag = self.backend.diagonal_tensor_to_block(self)
             new_diag = backend.block_backend.as_block(old_diag, dtype=dtype, device=device)
@@ -3086,11 +3102,14 @@ class Mask(Tensor):
 
         device = backend.block_backend.as_device(self.device if device is None else device)
         if isinstance(self.backend, FusionTreeBackend) and isinstance(backend, FusionTreeBackend):
-            new_data = self.backend.to_block_backend(self.data, backend.block_backend)
+            new_data = self.backend.to_block_backend(self.data, backend.block_backend, dtype=Dtype.bool, device=device)
         else:
             old_mask = self.backend.mask_to_block(self)
             new_mask = backend.block_backend.as_block(old_mask, dtype=Dtype.bool, device=device)
             new_data, _ = backend.mask_from_block(new_mask, large_leg=self.large_leg)
+            if isinstance(backend, AbelianBackend) and not self.is_projection:
+                # mask_from_block assumes projection mask -> swap block_inds for inclusion
+                new_data.block_inds = new_data.block_inds[:, ::-1]
         return Mask(
             new_data,
             space_in=self.domain[0],
@@ -4238,7 +4257,7 @@ def check_same_legs(t1: Tensor, t2: Tensor) -> tuple[list[int], list[int]] | Non
         if n2 != n1:
             incompatible_labels = True
             break
-    same_legs = t1.domain == t2.domain and t1.codomain == t1.codomain
+    same_legs = t1.domain == t2.domain and t1.codomain == t2.codomain
     if not same_legs:
         msg = 'Incompatible legs. '
         if incompatible_labels:
@@ -4416,6 +4435,7 @@ def combine_legs(
     domain_labels_reversed = []
     domain_spaces_reversed = []
     i = 0  # have already used pipes[:i]
+    label_offset = 0
     for n in range(N):
         if n in codomain_groups:
             group = codomain_groups[n]
@@ -4423,8 +4443,9 @@ def combine_legs(
             combined = tensor.backend.make_pipe(spaces_to_combine, is_dual=pipe_dualities[i], pipe=pipes[i])
             pipes[i] = combined
             codomain_spaces.append(combined)
-            codomain_labels.append(_combine_leg_labels(tensor.labels[group[0] : group[-1] + 1]))
+            codomain_labels.append(_combine_leg_labels(tensor.labels[group[0] : group[-1] + 1], label_offset))
             i += 1
+            label_offset += len([tensor.labels[l] for l in group if tensor.labels[l] is None])
         elif n in domain_groups:
             group = domain_groups[n]
             domain_idx1 = N - 1 - group[0]
@@ -4435,8 +4456,9 @@ def combine_legs(
             combined = tensor.backend.make_pipe(spaces_to_combine, is_dual=not pipe_dualities[i], pipe=pipes[i])
             pipes[i] = combined
             domain_spaces_reversed.append(combined)
-            domain_labels_reversed.append(_combine_leg_labels(tensor.labels[group[0] : group[-1] + 1]))
+            domain_labels_reversed.append(_combine_leg_labels(tensor.labels[group[0] : group[-1] + 1], label_offset))
             i += 1
+            label_offset += len([tensor.labels[l] for l in group if tensor.labels[l] is None])
         elif n in to_combine:
             # n is part of a group, but not the *first* of its group
             pass
@@ -7058,9 +7080,9 @@ def _check_compatible_legs(legs1: Sequence[Leg], legs2: Sequence[Leg], expect_eq
             raise ValueError('Incompatible legs.')
 
 
-def _combine_leg_labels(labels: list[str | None]) -> str:
+def _combine_leg_labels(labels: list[str | None], offset: int) -> str:
     """The label that a combined leg should have"""
-    return '(' + '.'.join(f'?{n}' if l is None else l for n, l in enumerate(labels)) + ')'
+    return '(' + '.'.join(f'?{n + offset}' if l is None else l for n, l in enumerate(labels)) + ')'
 
 
 def _convert_abelian_to_FT(tensor: SymmetricTensor, backend: FusionTreeBackend, dtype: Dtype, device: str):

--- a/tests/python_tests/test_tensors.py
+++ b/tests/python_tests/test_tensors.py
@@ -46,8 +46,14 @@ class DummyTensor(tensors.Tensor):
     def __init__(self, codomain, domain, backend, labels, dtype):
         super().__init__(codomain, domain, backend, labels, dtype, device='cpu')
 
+    def as_dtype(self, dtype):
+        raise NotImplementedError
+
     def copy(self, deep=True) -> tensors.Tensor:
         raise NotImplementedError
+
+    def to_backend(self, backend, dtype=None, device=None):
+        return NotImplementedError
 
     def to_dense_block(self, leg_order: list[int | str] = None, dtype: Dtype = None, understood_braiding: bool = False):
         raise NotImplementedError
@@ -200,6 +206,19 @@ def test_SymmetricTensor(make_compatible_tensor, leg_nums, use_pipes):
     _ = repr(T)
     _ = str(zero_tens)
     _ = repr(zero_tens)
+
+    print('checking as_dtype')
+    # use as_dtype and compare to to_backend
+    dtype = Dtype.complex64
+    T2 = T.as_dtype(dtype)
+    T2.test_sanity()
+    T3 = T.to_backend(T.backend, dtype)
+    T3.test_sanity()
+    assert T.dtype != T2.dtype
+    assert T2.dtype == dtype
+    assert T3.dtype == dtype
+    assert tensors.almost_equal(T, T2)
+    assert tensors.almost_equal(T, T3)
 
 
 @pytest.mark.parametrize('leg_num', [1, 2, 3])
@@ -527,6 +546,19 @@ def test_DiagonalTensor(make_compatible_tensor):
     npt.assert_almost_equal(real_T.max(), np.max(real_np))
     npt.assert_almost_equal(real_T.min(), np.min(real_np))
 
+    print('checking as_dtype')
+    # use as_dtype and compare to to_backend
+    dtype = Dtype.complex64
+    T2 = T.as_dtype(dtype)
+    T2.test_sanity()
+    T3 = T.to_backend(T.backend, dtype)
+    T3.test_sanity()
+    assert T.dtype != T2.dtype
+    assert T2.dtype == dtype
+    assert T3.dtype == dtype
+    assert tensors.almost_equal(T, T2)
+    assert tensors.almost_equal(T, T3)
+
 
 def test_Identity(compatible_backend, make_compatible_space, make_compatible_tensor):
     leg = make_compatible_space()
@@ -553,6 +585,19 @@ def test_Identity(compatible_backend, make_compatible_space, make_compatible_ten
 
     B_contr = tensors.compose(B, tens)
     assert tensors.norm(B_contr - B) < 1e-14
+
+    print('checking as_dtype')
+    # use as_dtype and compare to to_backend
+    dtype = Dtype.complex64
+    tens2 = tens.as_dtype(dtype)
+    tens2.test_sanity()
+    tens3 = tens.to_backend(tens.backend, dtype)
+    tens3.test_sanity()
+    assert tens.dtype != tens2.dtype
+    assert tens2.dtype == dtype
+    assert tens3.dtype == tens2.dtype
+    assert tensors.almost_equal(tens, tens2)
+    assert tensors.almost_equal(tens, tens3)
 
     # TODO test partial_compose!
 
@@ -704,6 +749,20 @@ def test_Mask(make_compatible_tensor, compatible_symmetry_backend, np_random):
     _ = str(M_zero)
     _ = repr(M_zero)
 
+    print('checking as_dtype')
+    # use as_dtype and compare to to_backend
+    dtype = Dtype.bool  # only bool possible
+    for T in [M_projection, M_inclusion]:
+        T2 = T.as_dtype(dtype)
+        T2.test_sanity()
+        T3 = T.to_backend(T.backend, dtype)
+        T3.test_sanity()
+        assert T.dtype == T2.dtype
+        assert T2.dtype == dtype
+        assert T3.dtype == dtype
+        assert tensors.almost_equal(T, T2)
+        assert tensors.almost_equal(T, T3)
+
 
 @pytest.mark.deselect_invalid_ChargedTensor_cases(get_cls=lambda kw: ChargedTensor)
 @pytest.mark.parametrize('leg_nums', [(1, 1), (2, 1), (3, 0), (0, 3)], ids=['1->1', '1->2', '0->3', '3->0'])
@@ -741,6 +800,19 @@ def test_ChargedTensor(make_compatible_tensor, leg_nums):
     _ = repr(T)
     _ = str(zero_tens)
     _ = repr(zero_tens)
+
+    print('checking as_dtype')
+    # use as_dtype and compare to to_backend
+    dtype = Dtype.complex64
+    T2 = T.as_dtype(dtype)
+    T2.test_sanity()
+    T3 = T.to_backend(T.backend, dtype)
+    T3.test_sanity()
+    assert T.dtype != T2.dtype
+    assert T2.dtype == dtype
+    assert T3.dtype == dtype
+    assert tensors.almost_equal(T, T2)
+    assert tensors.almost_equal(T, T3)
 
 
 @pytest.mark.deselect_invalid_ChargedTensor_cases(get_cls=lambda kw: ChargedTensor)


### PR DESCRIPTION
- [x] Add `as_dtype` for tensors + test
- [x] fix `to_backend`
- [x] add a dummy block to `Identity` to get the same device as for the other tensors (in torch block backend)