### PR TITLE
Coupling hashing, eq, permute, identity insertion

### DIFF
--- a/cyten/models/couplings.py
+++ b/cyten/models/couplings.py
@@ -12,10 +12,13 @@ import numpy as np
 
 from ..backends import get_same_backend
 from ..block_backends import Block, Dtype
-from ..symmetries import FibonacciAnyonCategory, Sector, SymmetryError, fibonacci_anyon_category
-from ..tensors import SymmetricTensor, add_trivial_leg, compose, horizontal_factorization, permute_legs, squeeze_legs
+from ..symmetries import FibonacciAnyonCategory, Sector, SymmetryError, TensorProduct, fibonacci_anyon_category
+from ..tensors import SymmetricTensor, add_trivial_leg, compose, horizontal_factorization, permute_legs, squeeze_legs, tdot
 from .degrees_of_freedom import ALL_SPECIES, BosonicDOF, ClockDOF, FermionicDOF, Site, SpinDOF
 from .sites import GoldenSite
+
+import base64
+import json
 
 
 class Coupling:
@@ -48,25 +51,31 @@ class Coupling:
 
     """
 
-    def __init__(self, sites: list[Site], factorization: list[SymmetricTensor], name: str = None):
+    def __init__(
+        self, sites: list[Site], factorization: list[SymmetricTensor], name: str = None, skip_sanity: bool = False
+    ):
         self.sites = sites
-        assert len(factorization) == len(sites)
+        assert len(factorization) == len(sites) or len(factorization) == len(sites) + 1
         self.factorization = factorization
         self.name = name
-        self.test_sanity()  # OPTIMIZE
+        if not skip_sanity:
+            self.test_sanity()
 
     def test_sanity(self):
         """Perform sanity checks."""
         backend = get_same_backend(*self.sites)
-        for s, W in zip(self.sites, self.factorization):
-            s.test_sanity()
+        site_idx = 0
+        for W in self.factorization:
             W.test_sanity()
             assert W.backend == backend
             assert W.num_codomain_legs == 2
             assert W.num_domain_legs == 2
             assert W.labels == ['wL', 'p', 'wR', 'p*']
-            assert W.get_leg_co_domain('p') == s.leg
-            assert W.get_leg_co_domain('p*') == s.leg
+            if site_idx < len(self.sites):
+                s = self.sites[site_idx]
+                assert W.get_leg_co_domain('p') == s.leg
+                assert W.get_leg_co_domain('p*') == s.leg
+                site_idx += 1
         assert self.factorization[0].get_leg('wL').is_trivial
         for W1, W2 in zip(self.factorization[:-1], self.factorization[1:]):
             assert W1.get_leg_co_domain('wR') == W2.get_leg_co_domain('wL')
@@ -205,6 +214,205 @@ class Coupling:
     ) -> np.ndarray:
         """Convert to a numpy array."""
         return self.to_tensor().to_numpy(leg_order, numpy_dtype, understood_braiding)
+
+    def insert_identity_between_sites(self, position: int) -> Coupling:
+        """
+        Insert identity tensor between sites at given position.
+        """
+
+        if position <= 0 or position >= len(self.sites):
+            raise ValueError(f'Position must be between 1 and {len(self.sites) - 1}, got {position}')
+
+        site_left = self.sites[position - 1]
+        site_right = self.sites[position]
+        leg = site_left.leg
+        backend = get_same_backend(site_left, site_right)
+
+        left_block = self.factorization[position - 1]
+        right_block = self.factorization[position]
+
+        wR_space = left_block.domain.factors[-1]
+        wL_space = right_block.codomain.factors[0]
+
+        if isinstance(wR_space, list) or isinstance(wL_space, list):
+            raise NotImplementedError('Multi-bond insertions not yet supported')
+
+        if leg != site_right.leg:
+            raise ValueError(f'Sites must have same physical leg.')
+
+        # Create identity via from_eye, permute, and relabel
+        identity_tensor = SymmetricTensor.from_eye(
+            co_domain=[leg, wR_space],
+            backend=backend,
+            labels=['p', 'w'],
+        )
+        # Permute: swap codomain legs so w moves to first position
+        identity_tensor = permute_legs(identity_tensor, codomain=['w', 'p'], domain=['p*', 'w*'], bend_right=False)
+        # Relabel to match [wL, p, wR, p*]
+        identity_tensor = identity_tensor.relabel({'w': 'wL', 'w*': 'wR'})
+
+        new_sites = self.sites[:position] + [site_left] + self.sites[position:]
+        new_factorization = (
+            self.factorization[:position]
+            + [identity_tensor]
+            + self.factorization[position:]
+        )
+
+        return Coupling(sites=new_sites, factorization=new_factorization, name=self.name, skip_sanity=True)
+
+
+    def to_hash(self) -> str:
+        """Compute a hash that uniquely identifies this coupling.
+
+        The hash is a base64-encoded JSON string containing all information needed
+        to reconstruct the coupling, including site parameters and tensor data.
+
+        Returns
+        -------
+        str
+            A unique hash string for this coupling.
+        """
+
+        def serialize_space(space):
+            """Serialize a Space (ElementarySpace) to a dict."""
+
+            def to_python_int(x):
+                """Convert numpy int to Python int for JSON serialization."""
+                if hasattr(x, 'item'):
+                    return x.item()
+                return int(x)
+
+            defining_sectors = space.defining_sectors
+            if hasattr(defining_sectors, 'tolist'):
+                defining_sectors = defining_sectors.tolist()
+            defining_sectors = [[to_python_int(s) for s in row] for row in defining_sectors]
+
+            return {
+                'symmetry': str(type(space.symmetry).__name__),
+                'defining_sectors': defining_sectors,
+                'sector_decomposition': [to_python_int(s) for s in space.sector_decomposition],
+                'multiplicities': [to_python_int(m) for m in space.multiplicities],
+                'is_dual': bool(space.is_dual),
+            }
+
+        def serialize_tensor(tensor):
+            """Serialize a SymmetricTensor to a dict."""
+            data_base64 = base64.b64encode(tensor.to_numpy().tobytes()).decode('ascii')
+            codomain_labels = tensor.codomain_labels
+            domain_labels = tensor.domain_labels
+            return {
+                'labels': [*codomain_labels, *domain_labels],
+                'codomain': [serialize_space(f) for f in tensor.codomain.factors],
+                'domain': [serialize_space(f) for f in tensor.domain.factors],
+                'data': data_base64,
+                'dtype': str(tensor.dtype),
+            }
+
+        def serialize_site(site):
+            """Serialize a Site to a dict."""
+            from .sites import SpinSite
+
+            result = {'type': type(site).__name__}
+            if isinstance(site, SpinSite):
+                result['S'] = site.S
+                result['conserve'] = site.conserve
+            else:
+                raise NotImplementedError(f'Serialization of {type(site).__name__} not implemented')
+            return result
+
+        data = {
+            'name': self.name,
+            'sites': [serialize_site(site) for site in self.sites],
+            'factorization': [serialize_tensor(t) for t in self.factorization],
+        }
+
+        json_str = json.dumps(data, sort_keys=True)
+        return base64.b64encode(json_str.encode('utf-8')).decode('ascii')
+
+    @classmethod
+    def from_hash(cls, hash_str: str) -> Coupling:
+        """Reconstruct a coupling from its hash.
+
+        Parameters
+        ----------
+        hash_str : str
+            The hash string previously returned by :meth:`to_hash`.
+
+        Returns
+        -------
+        Coupling
+            The reconstructed coupling.
+        """
+        import base64
+        import json
+        from ..backends import get_backend
+        from ..symmetries import ElementarySpace, NoSymmetry, SU2Symmetry, U1Symmetry, ZNSymmetry, Symmetry
+
+        def deserialize_space(data):
+            """Deserialize a dict to a Space (ElementarySpace)."""
+            sym_name = data['symmetry']
+            if sym_name == 'NoSymmetry':
+                sym = NoSymmetry()
+            elif sym_name == 'SU2Symmetry':
+                sym = SU2Symmetry()
+            elif sym_name == 'U1Symmetry':
+                sym = U1Symmetry()
+            elif sym_name == 'ZNSymmetry':
+                sym = ZNSymmetry(n=2)
+            else:
+                raise NotImplementedError(f'Symmetry {sym_name} not implemented')
+
+            sectors = data['defining_sectors']
+            mults = data['multiplicities']
+
+            if len(sectors) == 1 and len(sectors[0]) == 1 and sectors[0][0] == 0 and mults[0] > 1 and len(mults) == 1:
+                return ElementarySpace.from_trivial_sector(dim=mults[0], symmetry=sym)
+            return ElementarySpace.from_defining_sectors(sym, sectors, multiplicities=mults)
+
+        def deserialize_tensor(data, backend):
+            """Deserialize a dict to a SymmetricTensor."""
+            data_bytes = base64.b64decode(data['data'])
+            arr = np.frombuffer(data_bytes, dtype=np.complex128).reshape(-1).copy()
+
+            codomain = TensorProduct([deserialize_space(d) for d in data['codomain']])
+            domain = TensorProduct([deserialize_space(d) for d in data['domain']])
+
+            shape = tuple(f.dim for f in codomain.factors) + tuple(f.dim for f in reversed(domain.factors))
+            arr = arr.reshape(shape)
+
+            labels = data['labels']
+            codomain_labels = labels[: len(data['codomain'])]
+            domain_labels = labels[len(data['codomain']) :]
+
+            tensor = SymmetricTensor.from_dense_block(
+                arr,
+                codomain=codomain,
+                domain=domain,
+                labels=[codomain_labels, domain_labels],
+                backend=backend,
+                understood_braiding=True,
+            )
+            return tensor
+
+        def deserialize_site(data):
+            """Deserialize a dict to a Site."""
+            site_type = data['type']
+            if site_type == 'SpinSite':
+                from .sites import SpinSite
+
+                return SpinSite(S=data['S'], conserve=data['conserve'])
+            else:
+                raise NotImplementedError(f'Deserialization of {site_type} not implemented')
+
+        json_bytes = base64.b64decode(hash_str.encode('ascii'))
+        data = json.loads(json_bytes.decode('utf-8'))
+
+        sites = [deserialize_site(s) for s in data['sites']]
+        backend = get_same_backend(*sites)
+
+        factorization = [deserialize_tensor(t, backend) for t in data['factorization']]
+
+        return cls(sites=sites, factorization=factorization, name=data['name'], skip_sanity=True)
 
 
 # SPIN COUPLINGS

--- a/cyten/models/couplings.py
+++ b/cyten/models/couplings.py
@@ -8,17 +8,172 @@ two sites that have a spin degree of freedom.
 # Copyright (C) TeNPy Developers, Apache license
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from ..backends import get_same_backend
 from ..block_backends import Block, Dtype
-from ..symmetries import FibonacciAnyonCategory, Sector, SymmetryError, TensorProduct, fibonacci_anyon_category
-from ..tensors import SymmetricTensor, add_trivial_leg, compose, horizontal_factorization, permute_legs, squeeze_legs, tdot
+from ..symmetries import (
+    BraidChiralityUnspecifiedError,
+    FermionParity,
+    FibonacciAnyonCategory,
+    IsingAnyonCategory,
+    NoSymmetry,
+    SU2,
+    SU2_kAnyonCategory,
+    Sector,
+    SymmetryError,
+    U1,
+    ZN,
+    fibonacci_anyon_category,
+)
+from ..tensors import (
+    SymmetricTensor, add_trivial_leg, almost_equal, compose, horizontal_factorization, permute_legs,
+    squeeze_legs,
+)
 from .degrees_of_freedom import ALL_SPECIES, BosonicDOF, ClockDOF, FermionicDOF, Site, SpinDOF
-from .sites import GoldenSite
+from .sites import (
+    ClockSite, FibonacciAnyonSite, GoldenSite, IsingAnyonSite, SpinHalfFermionSite, SpinSite,
+    SpinlessBosonSite, SpinlessFermionSite, SU2kSpin1Site,
+)
 
-import base64
-import json
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+def _symmetry_factor_to_dict(factor) -> dict:
+    """Serialize a single SymmetryFactor to a dict."""
+    dn = factor.descriptive_name  # included for all types; Symmetry.__eq__ checks this
+    if isinstance(factor, NoSymmetry):
+        return {'type': 'NoSymmetry'}
+    if isinstance(factor, FermionParity):
+        return {'type': 'FermionParity', 'descriptive_name': dn}
+    if isinstance(factor, U1):
+        return {'type': 'U1', 'descriptive_name': dn}
+    if isinstance(factor, SU2):
+        return {'type': 'SU2', 'descriptive_name': dn}
+    if isinstance(factor, ZN):
+        return {'type': 'ZN', 'N': int(factor.N), 'descriptive_name': dn}
+    if isinstance(factor, FibonacciAnyonCategory):
+        return {'type': 'FibonacciAnyonCategory', 'handedness': factor.handedness}
+    if isinstance(factor, IsingAnyonCategory):
+        return {'type': 'IsingAnyonCategory', 'nu': int(factor.nu)}
+    if isinstance(factor, SU2_kAnyonCategory):
+        return {'type': 'SU2_kAnyonCategory', 'k': int(factor.k), 'handedness': factor.handedness}
+    raise NotImplementedError(
+        f'Cannot serialize symmetry factor {type(factor).__name__!r}. '
+        f'Add a branch to _symmetry_factor_to_dict.'
+    )
+
+
+def _symmetry_to_dict(sym) -> dict:
+    """Serialize a (possibly product) Symmetry to a dict."""
+    return {'factors': [_symmetry_factor_to_dict(f) for f in sym.factors]}
+
+
+def _space_to_dict(space) -> dict:
+    """Serialize a single ElementarySpace to a  dict."""
+    sectors = space.defining_sectors
+    if hasattr(sectors, 'tolist'):
+        sectors = sectors.tolist()
+    else:
+        sectors = [[(s.item() if hasattr(s, 'item') else int(s)) for s in row] for row in sectors]
+    bp = space._basis_perm
+    return {
+        'symmetry': _symmetry_to_dict(space.symmetry),
+        'sectors': sectors,
+        'multiplicities': [(m.item() if hasattr(m, 'item') else int(m)) for m in space.multiplicities],
+        'is_dual': bool(space.is_dual),
+        'basis_perm': bp.tolist() if bp is not None else None,
+    }
+
+
+def _site_to_dict(site) -> dict:
+    """Serialize a Site to a dict of {type, constructor-params}.
+
+    Only the parameters needed to reconstruct the site are stored — the physical
+    leg and operators are derived by the constructor, so they are not duplicated.
+    """
+    name = type(site).__name__
+    if isinstance(site, SpinSite):
+        return {'type': name, 'S': float(site.S), 'conserve': site.conserve}
+    if isinstance(site, SpinHalfFermionSite):
+        return {
+            'type': name,
+            'conserve_N': site.conserve_N,
+            'conserve_S': site.conserve_S,
+            'filling': site.filling,
+        }
+    if isinstance(site, SpinlessBosonSite):
+        Nmax = site.Nmax
+        if hasattr(Nmax, 'tolist'):
+            Nmax = Nmax.tolist()
+        elif hasattr(Nmax, '__iter__') and not isinstance(Nmax, (str, int)):
+            Nmax = list(Nmax)
+        return {'type': name, 'Nmax': Nmax, 'conserve': site.conserve, 'filling': site.filling}
+    if isinstance(site, SpinlessFermionSite):
+        return {
+            'type': name,
+            'num_species': site.num_species,
+            'conserve': site.conserve,
+            'filling': site.filling,
+        }
+    if isinstance(site, FibonacciAnyonSite):
+        return {'type': name, 'handedness': site.symmetry.handedness}
+    if isinstance(site, IsingAnyonSite):
+        return {'type': name, 'nu': int(site.symmetry.nu)}
+    if isinstance(site, GoldenSite):
+        return {'type': name, 'handedness': site.symmetry.handedness}
+    if isinstance(site, SU2kSpin1Site):
+        return {'type': name, 'k': int(site.symmetry.k), 'handedness': site.symmetry.handedness}
+    if isinstance(site, ClockSite):
+        return {'type': name, 'q': int(site.q), 'conserve': site.conserve}
+    raise NotImplementedError(
+        f'Cannot serialize site type {name!r}. '
+        f'Add a branch to _site_to_dict.'
+    )
+
+
+def _adjacent_transpositions(permutation: Sequence[int]) -> list[int]:
+    """Decompose a permutation into a sequence of adjacent position swaps.
+
+    Parameters
+    ----------
+    permutation : list of int
+        A permutation of ``range(len(permutation))``; ``permutation[k]`` is the value that ends
+        up at position `k`.
+
+    Returns
+    -------
+    swap_positions : list of int
+        Positions `pos` such that applying the swaps ``(pos, pos + 1)`` in order to
+        ``list(range(len(permutation)))`` produces `permutation`. Realizes `permutation` with the
+        minimal number of adjacent transpositions, i.e. its number of inversions.
+
+    """
+    n = len(permutation)
+    working = list(range(n))
+    swap_positions = []
+    for target_pos in range(n):
+        value = permutation[target_pos]
+        cur = working.index(value, target_pos)
+        while cur > target_pos:
+            swap_positions.append(cur - 1)
+            working[cur - 1], working[cur] = working[cur], working[cur - 1]
+            cur -= 1
+    assert working == list(permutation)
+    return swap_positions
+
+
+def freeze(obj):
+    """Recursively turn the output of the ``_*_to_dict`` helpers into hashable nested tuples."""
+    if isinstance(obj, dict):
+        return tuple((k, freeze(v)) for k, v in sorted(obj.items()))
+    if isinstance(obj, (list, tuple)):
+        return tuple(freeze(v) for v in obj)
+    return obj
 
 
 class Coupling:
@@ -55,9 +210,12 @@ class Coupling:
         self, sites: list[Site], factorization: list[SymmetricTensor], name: str = None, skip_sanity: bool = False
     ):
         self.sites = sites
-        assert len(factorization) == len(sites) or len(factorization) == len(sites) + 1
+        assert len(factorization) == len(sites) #or len(factorization) == len(sites) + 1
         self.factorization = factorization
         self.name = name
+        self._levels: list[int] = list(range(1, len(sites) + 1))
+        # cache of previously computed permutations of this instance, filled by :meth:`permute`.
+        self._permuted: list[tuple[tuple[int, ...], Coupling]] = []
         if not skip_sanity:
             self.test_sanity()
 
@@ -80,6 +238,58 @@ class Coupling:
         for W1, W2 in zip(self.factorization[:-1], self.factorization[1:]):
             assert W1.get_leg_co_domain('wR') == W2.get_leg_co_domain('wL')
         assert self.factorization[-1].get_leg('wR').is_trivial
+
+    def _key(self):
+        """Structural identity used by :meth:`__hash__`/:meth:`__eq__`.
+
+        Contains only hashable metadata, no floating-point tensor
+        data, which is instead compared numerically (via :func:`~cyten.tensors.almost_equal`) in
+        :meth:`__eq__`. This is what determines whether two (distinct) `Coupling` instances may
+        share the same key in an :class:`~tenpy.networks.mpo.MPOGraph`.
+
+        Note that `Coupling` is currently mutable, so this key/``__hash__``/``__eq__`` scheme is
+        only correct as long as a coupling already used as a dict key isn't mutated afterwards;
+        enforcing immutability is left for a future translation of this code to C++.
+        """
+        return (
+            self.name,
+            tuple(freeze(_site_to_dict(s)) for s in self.sites),
+            tuple(
+                (
+                    tuple(t.shape),
+                    tuple(t.labels),
+                    t.dtype.name,
+                    tuple(freeze(_space_to_dict(f)) for f in t.codomain.factors),
+                    tuple(freeze(_space_to_dict(f)) for f in t.domain.factors),
+                )
+                for t in self.factorization
+            ),
+        )
+
+    def __hash__(self):
+        # recomputed on every call (not cached): see the mutability note in :meth:`_key`.
+        return hash(self._key())
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, Coupling):
+            return NotImplemented
+        if self._key() != other._key():
+            return False
+        # `_key()` already guarantees matching legs for corresponding tensors, so `almost_equal`
+        # (which requires identical legs) cannot raise here.
+        for t1, t2 in zip(self.factorization, other.factorization):
+            if t1 is t2:
+                continue
+            if not almost_equal(t1, t2):
+                return False
+        return True
+
+    def __repr__(self):
+        site_names = [type(s).__name__ for s in self.sites]
+        shapes = [tuple(t.shape) for t in self.factorization]
+        return f'Coupling(name={self.name!r}, sites={site_names}, shapes={shapes})'
 
     @classmethod
     def from_dense_block(
@@ -216,10 +426,7 @@ class Coupling:
         return self.to_tensor().to_numpy(leg_order, numpy_dtype, understood_braiding)
 
     def insert_identity_between_sites(self, position: int) -> Coupling:
-        """
-        Insert identity tensor between sites at given position.
-        """
-
+        """Insert identity tensor between sites at given position."""
         if position <= 0 or position >= len(self.sites):
             raise ValueError(f'Position must be between 1 and {len(self.sites) - 1}, got {position}')
 
@@ -250,160 +457,114 @@ class Coupling:
 
         return Coupling(sites=new_sites, factorization=new_factorization, name=self.name, skip_sanity=True)
 
+    def permute(
+        self, permutation: Sequence[int], levels: Sequence[int | None], over_braid: Sequence[bool | None]
+    ) -> Coupling:
+        """Permute the sites of this coupling, braiding through the (possibly anyonic) legs.
 
-    def to_hash(self) -> str:
-        """Compute a hash that uniquely identifies this coupling.
+        Contracts `self` to a single tensor (:meth:`to_tensor`), realizes `permutation` as a
+        sequence of elementary adjacent-site transpositions (each one braiding the full ``(p, p*)``
+        leg pair of one site past that of its neighbour, as a single unit -- the two legs of one
+        site never cross each other), and re-factorizes the result (:meth:`from_tensor`) with the
+        sites reordered accordingly. This is analogous to how
+        :class:`~cyten.backends.fusion_tree_backend.PermuteLegsInstructionEngine` realizes a leg
+        permutation as a sequence of elementary swaps, tracking a `levels` list that is itself
+        reordered as legs move.
 
-        The hash is a base64-encoded JSON string containing all information needed
-        to reconstruct the coupling, including site parameters and tensor data.
-
-        Returns
-        -------
-        str
-            A unique hash string for this coupling.
-        """
-
-        def serialize_space(space):
-            """Serialize a Space (ElementarySpace) to a dict."""
-
-            def to_python_int(x):
-                """Convert numpy int to Python int for JSON serialization."""
-                if hasattr(x, 'item'):
-                    return x.item()
-                return int(x)
-
-            defining_sectors = space.defining_sectors
-            if hasattr(defining_sectors, 'tolist'):
-                defining_sectors = defining_sectors.tolist()
-            defining_sectors = [[to_python_int(s) for s in row] for row in defining_sectors]
-
-            return {
-                'symmetry': str(type(space.symmetry).__name__),
-                'defining_sectors': defining_sectors,
-                'sector_decomposition': [to_python_int(s) for s in space.sector_decomposition],
-                'multiplicities': [to_python_int(m) for m in space.multiplicities],
-                'is_dual': bool(space.is_dual),
-            }
-
-        def serialize_tensor(tensor):
-            """Serialize a SymmetricTensor to a dict."""
-            data_base64 = base64.b64encode(tensor.to_numpy().tobytes()).decode('ascii')
-            codomain_labels = tensor.codomain_labels
-            domain_labels = tensor.domain_labels
-            return {
-                'labels': [*codomain_labels, *domain_labels],
-                'codomain': [serialize_space(f) for f in tensor.codomain.factors],
-                'domain': [serialize_space(f) for f in tensor.domain.factors],
-                'data': data_base64,
-                'dtype': str(tensor.dtype),
-            }
-
-        def serialize_site(site):
-            """Serialize a Site to a dict."""
-            from .sites import SpinSite
-
-            result = {'type': type(site).__name__}
-            if isinstance(site, SpinSite):
-                result['S'] = site.S
-                result['conserve'] = site.conserve
-            else:
-                raise NotImplementedError(f'Serialization of {type(site).__name__} not implemented')
-            return result
-
-        data = {
-            'name': self.name,
-            'sites': [serialize_site(site) for site in self.sites],
-            'factorization': [serialize_tensor(t) for t in self.factorization],
-        }
-
-        json_str = json.dumps(data, sort_keys=True)
-        return base64.b64encode(json_str.encode('utf-8')).decode('ascii')
-
-    @classmethod
-    def from_hash(cls, hash_str: str) -> Coupling:
-        """Reconstruct a coupling from its hash.
+        Results are cached on `self` (not shared with `self`'s other permutations, or with the
+        result of this call): calling ``self.permute(permutation, ...)`` twice with the same
+        `permutation` returns the same (cached) result, using `levels`/`over_braid` only the first
+        time; a different `permutation` triggers a new computation.
 
         Parameters
         ----------
-        hash_str : str
-            The hash string previously returned by :meth:`to_hash`.
+        permutation : list of int
+            A permutation of ``range(len(self.sites))``. ``permutation[k]`` is the index (in
+            `self`'s current order) of the site that ends up at new position `k`.
+        levels : list of int | None
+            One entry per site of `self` (in `self`'s current order): its "height", used to
+            derive the braid chirality (over/under) for any elementary transposition whose
+            `over_braid` entry is ``None``, the same way :attr:`~cyten.symmetries.Symmetry` legs
+            with a higher level braid over those with a lower one. Only needed for symmetries
+            without a symmetric braid (see :attr:`~cyten.symmetries.Symmetry.braiding_style`);
+            ignored otherwise.
+        over_braid : list of bool | None
+            One entry per elementary adjacent-site transposition needed to realize `permutation`
+            (i.e. NOT one entry per site -- the number of transpositions depends on
+            `permutation`, e.g. via the number of its inversions). Explicitly fixes the braid
+            chirality for that transposition (``True`` = the site moving from the lower position
+            over the one moving from the higher position); ``None`` derives it from `levels`.
 
         Returns
         -------
         Coupling
-            The reconstructed coupling.
+            A new coupling with :attr:`sites` (and the represented operator) reordered according
+            to `permutation`.
+
         """
-        import base64
-        import json
-        from ..backends import get_backend
-        from ..symmetries import ElementarySpace, NoSymmetry, SU2Symmetry, U1Symmetry, ZNSymmetry, Symmetry
+        n = len(self.sites)
+        permutation = list(permutation)
+        if sorted(permutation) != list(range(n)):
+            raise ValueError(f'`permutation` must be a permutation of range({n}), got {permutation}')
+        if len(levels) != n:
+            raise ValueError(f'need {n} `levels`, one per site, got {len(levels)}')
 
-        def deserialize_space(data):
-            """Deserialize a dict to a Space (ElementarySpace)."""
-            sym_name = data['symmetry']
-            if sym_name == 'NoSymmetry':
-                sym = NoSymmetry()
-            elif sym_name == 'SU2Symmetry':
-                sym = SU2Symmetry()
-            elif sym_name == 'U1Symmetry':
-                sym = U1Symmetry()
-            elif sym_name == 'ZNSymmetry':
-                sym = ZNSymmetry(n=2)
-            else:
-                raise NotImplementedError(f'Symmetry {sym_name} not implemented')
+        key = tuple(permutation)
+        for cached_key, cached_coupling in self._permuted:
+            if cached_key == key:
+                return cached_coupling
 
-            sectors = data['defining_sectors']
-            mults = data['multiplicities']
-
-            if len(sectors) == 1 and len(sectors[0]) == 1 and sectors[0][0] == 0 and mults[0] > 1 and len(mults) == 1:
-                return ElementarySpace.from_trivial_sector(dim=mults[0], symmetry=sym)
-            return ElementarySpace.from_defining_sectors(sym, sectors, multiplicities=mults)
-
-        def deserialize_tensor(data, backend):
-            """Deserialize a dict to a SymmetricTensor."""
-            data_bytes = base64.b64decode(data['data'])
-            arr = np.frombuffer(data_bytes, dtype=np.complex128).reshape(-1).copy()
-
-            codomain = TensorProduct([deserialize_space(d) for d in data['codomain']])
-            domain = TensorProduct([deserialize_space(d) for d in data['domain']])
-
-            shape = tuple(f.dim for f in codomain.factors) + tuple(f.dim for f in reversed(domain.factors))
-            arr = arr.reshape(shape)
-
-            labels = data['labels']
-            codomain_labels = labels[: len(data['codomain'])]
-            domain_labels = labels[len(data['codomain']) :]
-
-            tensor = SymmetricTensor.from_dense_block(
-                arr,
-                codomain=codomain,
-                domain=domain,
-                labels=[codomain_labels, domain_labels],
-                backend=backend,
-                understood_braiding=True,
+        swap_positions = _adjacent_transpositions(permutation)
+        if len(over_braid) != len(swap_positions):
+            raise ValueError(
+                f'need {len(swap_positions)} entries in `over_braid` (one per elementary '
+                f'adjacent transposition realizing this permutation), got {len(over_braid)}'
             )
-            return tensor
 
-        def deserialize_site(data):
-            """Deserialize a dict to a Site."""
-            site_type = data['type']
-            if site_type == 'SpinSite':
-                from .sites import SpinSite
+        tensor = self.to_tensor()
+        sites = list(self.sites)
+        levels_state = list(levels)
+        # current label (p{original_idx} / p{original_idx}*) at each position; labels are
+        # intrinsic to a leg and travel with it, only their position changes.
+        codomain_labels = [f'p{i}' for i in range(n)]
+        domain_labels = [f'p{i}*' for i in range(n)]
 
-                return SpinSite(S=data['S'], conserve=data['conserve'])
-            else:
-                raise NotImplementedError(f'Deserialization of {site_type} not implemented')
+        for step, pos in enumerate(swap_positions):
+            over = over_braid[step]
+            if over is None:
+                level_1, level_2 = levels_state[pos], levels_state[pos + 1]
+                if level_1 is None or level_2 is None:
+                    raise BraidChiralityUnspecifiedError('Sites that braid must have specified levels.')
+                if level_1 == level_2:
+                    raise BraidChiralityUnspecifiedError('Sites that braid can not have the same level.')
+                over = level_1 > level_2
+            new_codomain = list(codomain_labels)
+            new_codomain[pos], new_codomain[pos + 1] = new_codomain[pos + 1], new_codomain[pos]
+            new_domain = list(domain_labels)
+            new_domain[pos], new_domain[pos + 1] = new_domain[pos + 1], new_domain[pos]
+            # ket and bra of the same site have the same level: they move together and never
+            # cross each other.
+            level_dict = {
+                codomain_labels[pos]: 1 if over else 0,
+                domain_labels[pos]: 1 if over else 0,
+                codomain_labels[pos + 1]: 0 if over else 1,
+                domain_labels[pos + 1]: 0 if over else 1,
+            }
+            tensor = permute_legs(tensor, codomain=new_codomain, domain=new_domain, levels=level_dict)
+            codomain_labels, domain_labels = new_codomain, new_domain
+            sites[pos], sites[pos + 1] = sites[pos + 1], sites[pos]
+            levels_state[pos], levels_state[pos + 1] = levels_state[pos + 1], levels_state[pos]
 
-        json_bytes = base64.b64decode(hash_str.encode('ascii'))
-        data = json.loads(json_bytes.decode('utf-8'))
+        relabelling = {}
+        for new_pos, old_idx in enumerate(permutation):
+            relabelling[f'p{old_idx}'] = f'p{new_pos}'
+            relabelling[f'p{old_idx}*'] = f'p{new_pos}*'
+        tensor = tensor.relabel(relabelling)
 
-        sites = [deserialize_site(s) for s in data['sites']]
-        backend = get_same_backend(*sites)
-
-        factorization = [deserialize_tensor(t, backend) for t in data['factorization']]
-
-        return cls(sites=sites, factorization=factorization, name=data['name'], skip_sanity=True)
-
+        result = Coupling.from_tensor(tensor, sites=sites, name=self.name)
+        result._levels = [self._levels[i] for i in permutation]
+        self._permuted.append((key, result))
+        return result
 
 # SPIN COUPLINGS
 

--- a/cyten/models/couplings.py
+++ b/cyten/models/couplings.py
@@ -225,8 +225,6 @@ class Coupling:
 
         site_left = self.sites[position - 1]
         site_right = self.sites[position]
-        leg = site_left.leg
-        backend = get_same_backend(site_left, site_right)
 
         left_block = self.factorization[position - 1]
         right_block = self.factorization[position]
@@ -237,24 +235,16 @@ class Coupling:
         if isinstance(wR_space, list) or isinstance(wL_space, list):
             raise NotImplementedError('Multi-bond insertions not yet supported')
 
-        if leg != site_right.leg:
-            raise ValueError(f'Sites must have same physical leg.')
+        if site_left.leg != site_right.leg:
+            raise ValueError('Sites must have same physical leg.')
 
-        # Create identity via from_eye, permute, and relabel
-        identity_tensor = SymmetricTensor.from_eye(
-            co_domain=[leg, wR_space],
-            backend=backend,
-            labels=['p', 'w'],
-        )
-        # Permute: swap codomain legs so w moves to first position
-        identity_tensor = permute_legs(identity_tensor, codomain=['w', 'p'], domain=['p*', 'w*'], bend_right=False)
-        # Relabel to match [wL, p, wR, p*]
-        identity_tensor = identity_tensor.relabel({'w': 'wL', 'w*': 'wR'})
+        # delegates to Site.identity_tensor, which also checks wR_space == wL_space
+        identity = site_left.identity_tensor(wR_space, wL_space)
 
         new_sites = self.sites[:position] + [site_left] + self.sites[position:]
         new_factorization = (
             self.factorization[:position]
-            + [identity_tensor]
+            + [identity]
             + self.factorization[position:]
         )
 

--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -247,19 +247,14 @@ class Site:
         """Build an identity MPO tensor for this site with the given virtual legs.
 
         Returns a 4-leg tensor with legs ``[wL, p, wR, p*]``; the physical legs carry :attr:`leg`.
-        Follows the convention of :meth:`~cyten.tensors.SymmetricTensor.from_eye`, which uses
-        ``domain=co_domain`` (the same underlying space, not its dual): `wR` must therefore be
-        the *same* :class:`~cyten.symmetries.ElementarySpace` as `wL` (both the non-dual,
-        codomain-style representative of the virtual bond, as e.g. returned by
-        ``W.get_leg_co_domain('wR')`` / ``W.get_leg_co_domain('wL')`` on adjacent MPO blocks).
-        A :class:`ValueError` is raised if ``wR != wL``.
+        This tensor acts as identity map between wL and wR, and is symmetric under the symmetry of this site.
 
         Parameters
         ----------
         wL, wR : ElementarySpace
             Left and right virtual legs of the returned tensor. Must be equal.
         overbraid : bool
-            Controls the braiding direction when the virtual leg is permuted past the physical
+            Braiding direction when the virtual leg is permuted past the physical
             leg. ``True`` (default) uses an over-braid (``bend_right=False`` in
             :func:`~cyten.tensors.permute_legs`); ``False`` uses an under-braid (``bend_right=True``).
 

--- a/cyten/models/degrees_of_freedom.py
+++ b/cyten/models/degrees_of_freedom.py
@@ -29,7 +29,7 @@ from ..symmetries import (
     SymmetryError,
     SymmetryFactor,
 )
-from ..tensors import DiagonalTensor, Identity, SymmetricTensor, compose
+from ..tensors import DiagonalTensor, Identity, SymmetricTensor, compose, permute_legs
 from ..tools import as_immutable_array, is_iterable, to_iterable, to_valid_idx
 
 ALL_SPECIES = object()
@@ -156,6 +156,10 @@ class Site:
             )
         self.onsite_operators[name] = op
 
+    def valid_opname(self, name: str) -> bool:
+        """Whether `name` labels a valid onsite operator of this site."""
+        return name in self.onsite_operators
+
     def get_op(self, name: str) -> SymmetricTensor:
         """Return operator of given name.
 
@@ -238,6 +242,38 @@ class Site:
                 next_op = self.get_op(next_op)
             op = compose(op, next_op)
         return op
+
+    def identity_tensor(self, wL: ElementarySpace, wR: ElementarySpace, overbraid: bool = True) -> SymmetricTensor:
+        """Build an identity MPO tensor for this site with the given virtual legs.
+
+        Returns a 4-leg tensor with legs ``[wL, p, wR, p*]``; the physical legs carry :attr:`leg`.
+        Follows the convention of :meth:`~cyten.tensors.SymmetricTensor.from_eye`, which uses
+        ``domain=co_domain`` (the same underlying space, not its dual): `wR` must therefore be
+        the *same* :class:`~cyten.symmetries.ElementarySpace` as `wL` (both the non-dual,
+        codomain-style representative of the virtual bond, as e.g. returned by
+        ``W.get_leg_co_domain('wR')`` / ``W.get_leg_co_domain('wL')`` on adjacent MPO blocks).
+        A :class:`ValueError` is raised if ``wR != wL``.
+
+        Parameters
+        ----------
+        wL, wR : ElementarySpace
+            Left and right virtual legs of the returned tensor. Must be equal.
+        overbraid : bool
+            Controls the braiding direction when the virtual leg is permuted past the physical
+            leg. ``True`` (default) uses an over-braid (``bend_right=False`` in
+            :func:`~cyten.tensors.permute_legs`); ``False`` uses an under-braid (``bend_right=True``).
+
+        Returns
+        -------
+        SymmetricTensor
+            Identity tensor with legs ``[wL, p, wR, p*]``.
+
+        """
+        if wR != wL:
+            raise ValueError(f'wR must equal wL for an identity tensor, got wR={wR}, wL={wL}')
+        tensor = SymmetricTensor.from_eye(co_domain=[self.leg, wL], backend=self.backend, labels=['p', 'w'])
+        tensor = permute_legs(tensor, codomain=['w', 'p'], domain=['p*', 'w*'], bend_right=not overbraid)
+        return tensor.relabel({'w': 'wL', 'w*': 'wR'})
 
     def state_index(self, label: str | int) -> int:
         """The index of a basis state."""

--- a/cyten/models/sites.py
+++ b/cyten/models/sites.py
@@ -22,7 +22,8 @@ from ..symmetries import (
     SU2_kAnyonCategory,
     Symmetry,
 )
-from .degrees_of_freedom import AnyonDOF, BosonicDOF, ClockDOF, FermionicDOF, SpinDOF
+from ..tensors import SymmetricTensor
+from .degrees_of_freedom import AnyonDOF, BosonicDOF, ClockDOF, FermionicDOF, Site, SpinDOF
 
 
 class SpinSite(SpinDOF):
@@ -774,3 +775,19 @@ class SU2kSpin1Site(AnyonDOF):
 
     def __repr__(self):
         return f'SU2kSpin1Site(k={self.symmetry.k}, handedness={self.symmetry.handedness})'
+
+
+def identity_tensor(
+    site: Site,
+    wL: ElementarySpace,
+    wR: ElementarySpace,
+    overbraid: bool = True,
+) -> SymmetricTensor:
+    """Create an identity MPO tensor for *site* with the given virtual legs.
+
+    Thin wrapper kept for backwards compatibility; the actual implementation now lives on
+    :meth:`~cyten.models.degrees_of_freedom.Site.identity_tensor`, since it is a property of any
+    individual site rather than something specific to this module. Prefer calling
+    ``site.identity_tensor(wL, wR)`` directly. See that method for the full docstring.
+    """
+    return site.identity_tensor(wL, wR, overbraid=overbraid)

--- a/tests/python_tests/models/test_couplings.py
+++ b/tests/python_tests/models/test_couplings.py
@@ -13,6 +13,20 @@ import cyten
 from cyten import SymmetryError, backends, tensors
 from cyten.models import couplings, degrees_of_freedom, sites
 
+# from cyten.models.sites import SpinSite
+# from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
+#from tenpy.networks.mpo import MPO
+
+from cyten.models.sites import SpinSite
+from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
+from cyten.tensors import permute_legs
+
+try:
+    from sympy import S as sympy_S
+except ImportError:
+    sympy_S = None
+
+assert sympy_S is not None and callable(sympy_S), "sympy_S is not set correctly"
 
 def check_coupling(coupling_cls, site_num: int, invalid_site_nums: list[int], boson_fermion_mixing: bool, **kwargs):
     """Perform common checks that make sense for any coupling"""
@@ -661,3 +675,672 @@ def test_gold_coupling(block_backend):
     npt.assert_almost_equal(tensors.trace(tensor), -1)
 
     check_coupling(couplings.gold_coupling, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=False)
+
+
+# def test_insert_identity_between_sites(block_backend):
+#     """Test inserting identity tensors between sites in a coupling."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
+#     coupling.test_sanity()
+#
+#     for pos in [1, 2]:
+#         new_coupling = coupling.insert_identity_between_sites(position=pos)
+#
+#         assert len(new_coupling.sites) == len(coupling.sites)
+#         assert len(new_coupling.factorization) == len(coupling.factorization) + 1
+#
+#
+# def test_insert_identity_between_sites_invalid_position(block_backend):
+#     """Test that invalid positions raise errors."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.heisenberg_coupling([site, site], J=1.0)
+#
+#     with pytest.raises(ValueError, match='Position must be between'):
+#         coupling.insert_identity_between_sites(position=0)
+#
+#     with pytest.raises(ValueError, match='Position must be between'):
+#         coupling.insert_identity_between_sites(position=2)
+#
+#     with pytest.raises(ValueError, match='Position must be between'):
+#         coupling.insert_identity_between_sites(position=-1)
+#
+#
+# def test_insert_identity_between_sites_single_site(block_backend):
+#     """Test that inserting identity on single-site coupling fails."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.spin_field_coupling([site], hz=1.0)
+#
+#     with pytest.raises(ValueError, match='Position must be between'):
+#         coupling.insert_identity_between_sites(position=1)
+#
+#
+# def test_insert_identity_between_sites_different_backends(block_backend):
+#     """Test identity insertion with different backends using a 3-site spin coupling."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
+#
+#     for pos in [1, 2]:
+#         new_coupling = coupling.insert_identity_between_sites(position=pos)
+#         assert len(new_coupling.sites) == len(coupling.sites)
+#         assert len(new_coupling.factorization) == len(coupling.factorization) + 1
+
+
+# def test_coupling_hash_roundtrip(block_backend):
+#     """Test that to_hash and from_hash correctly roundtrip a coupling."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.heisenberg_coupling([site, site], J=1.0)
+#     coupling.test_sanity()
+#
+#     hash_str = coupling.to_hash()
+#     reconstructed = couplings.Coupling.from_hash(hash_str)
+#
+#     assert reconstructed.name == coupling.name
+#     assert len(reconstructed.sites) == len(coupling.sites)
+#     assert len(reconstructed.factorization) == len(coupling.factorization)
+#
+#     assert hash_str == reconstructed.to_hash()
+#
+#
+# def test_coupling_hash_3site(block_backend):
+#     """Test hash for 3-site couplings."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
+#     coupling.test_sanity()
+#
+#     hash_str = coupling.to_hash()
+#     reconstructed = couplings.Coupling.from_hash(hash_str)
+#
+#     assert reconstructed.name == coupling.name
+#     assert len(reconstructed.sites) == len(coupling.sites)
+#     assert len(reconstructed.factorization) == len(coupling.factorization)
+#     assert hash_str == reconstructed.to_hash()
+#
+#
+# def test_coupling_hash_with_identity(block_backend):
+#     """Test hash for couplings with identity inserted."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
+#     coupling.test_sanity()
+#
+#     coupling_with_id = coupling.insert_identity_between_sites(position=1)
+#     hash_str = coupling_with_id.to_hash()
+#     reconstructed = couplings.Coupling.from_hash(hash_str)
+#
+#     assert reconstructed.name == coupling_with_id.name
+#     assert len(reconstructed.sites) == len(coupling_with_id.sites)
+#     assert len(reconstructed.factorization) == len(coupling_with_id.factorization)
+#     assert hash_str == reconstructed.to_hash()
+#
+#
+# def test_coupling_hash_deterministic(block_backend):
+#     """Test that hash is deterministic for same coupling."""
+#     backend = backends.get_backend(block_backend=block_backend)
+#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+#
+#     coupling1 = couplings.heisenberg_coupling([site, site], J=1.0)
+#     coupling2 = couplings.heisenberg_coupling([site, site], J=1.0)
+#
+#     hash1 = coupling1.to_hash()
+#     hash2 = coupling2.to_hash()
+#
+#     assert hash1 == hash2
+
+class SimpleTestGraph:
+    """Minimal mock MPO-like object for testing _make_graph_from_couplings."""
+
+    def __init__(self, L):
+        self.L = L
+        self._graph = None
+
+
+
+def test_coupling_hash_different_for_different_couplings(block_backend):
+    """Test that different couplings have different hashes."""
+    backend = backends.get_backend(block_backend=block_backend)
+    site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
+
+    coupling1 = couplings.heisenberg_coupling([site, site], J=1.0)
+    coupling2 = couplings.heisenberg_coupling([site, site], J=2.0)
+
+    hash1 = coupling1.to_hash()
+    hash2 = coupling2.to_hash()
+
+    assert hash1 != hash2
+
+
+def test_MPO_graph_from_couplings():
+    """Test building MPO graph from couplings using hashing."""
+
+    pytest.skip('Test currently depends on tenpy.')
+
+    L = 4
+    spin_sites = [SpinSite(S=0.5, conserve='Sz') for _ in range(L)]
+
+    coupling1 = heisenberg_coupling([spin_sites[0], spin_sites[1]], J=1.0)
+    coupling2 = heisenberg_coupling([spin_sites[0], spin_sites[1]], J=2.0)
+    coupling3 = spin_field_coupling([spin_sites[0]], hz=0.5)
+
+    couplings = [coupling1, coupling2, coupling3]
+
+    hashes = [c.to_hash() for c in couplings]
+    assert len(hashes) == len(couplings)
+    assert hashes[0] != hashes[1]
+    assert hashes[0] != hashes[2]
+
+    test_graph = SimpleTestGraph(L)
+
+    MPO._make_graph_from_couplings(test_graph, couplings)
+
+    assert test_graph._graph is not None
+    assert len(test_graph._graph) == L
+
+    for site_graph in test_graph._graph:
+        assert isinstance(site_graph, dict)
+
+
+def test_MPO_graph_from_couplings_identity_insertion():
+    """Test building MPO graph from cyten Couplings with identity insertion."""
+
+    pytest.skip('Test currently depends on tenpy.')
+
+    L = 4
+    spin_sites = [SpinSite(S=0.5, conserve='Sz') for _ in range(L)]
+
+    coupling = heisenberg_coupling([spin_sites[0], spin_sites[2]], J=1.0)
+
+    coupling_with_identity = coupling.insert_identity_between_sites(1)
+
+    assert len(coupling_with_identity.factorization) == len(coupling.factorization) + 1
+    assert len(coupling_with_identity.sites) == len(coupling.sites)
+
+    hash_original = coupling.to_hash()
+    hash_with_identity = coupling_with_identity.to_hash()
+    assert hash_original != hash_with_identity
+
+    couplings = [coupling_with_identity]
+
+    test_graph = SimpleTestGraph(L)
+
+    MPO._make_graph_from_couplings(test_graph, couplings)
+
+    assert test_graph._graph is not None
+    assert len(test_graph._graph) == L
+
+
+def test_MPO_graph_from_couplings_hash():
+    """Test that coupling hashing correctly identifies unique couplings."""
+
+
+    spin_site1 = SpinSite(S=0.5, conserve='Sz')
+    spin_site2 = SpinSite(S=0.5, conserve='Sz')
+
+    coupling_J1 = heisenberg_coupling([spin_site1, spin_site2], J=1.0)
+    coupling_J1p = heisenberg_coupling([spin_site1, spin_site2], J=1.0)
+
+    coupling_J2 = heisenberg_coupling([spin_site1, spin_site2], J=2.0)
+    coupling_J2p = heisenberg_coupling([spin_site1, spin_site2], J=2.0)
+    coupling_diff_J = spin_field_coupling([spin_site1], hz=0.5)
+
+    hash1 = coupling_J1.to_hash()
+    hash1p= coupling_J1p.to_hash()
+
+    hash2 = coupling_J2.to_hash()
+    hash2p = coupling_J2p.to_hash()
+
+    hash3 = coupling_diff_J.to_hash()
+
+
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3
+
+    assert hash1p == hash1
+    assert hash2p == hash2
+
+
+def test_coupling_hashing():
+    """Test that coupling hashing correctly distinguishes different couplings."""
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+
+    coupling_J1 = heisenberg_coupling([spin_site, spin_site], J=1.0)
+    coupling_J2 = heisenberg_coupling([spin_site, spin_site], J=2.0)
+    coupling_spin_field = spin_field_coupling([spin_site], hz=0.5)
+
+    hash1 = coupling_J1.to_hash()
+    hash2 = coupling_J2.to_hash()
+    hash3 = coupling_spin_field.to_hash()
+
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3
+
+
+@pytest.mark.parametrize(
+    "coupling_factory,site_args,coupling_kwargs,valid_positions",
+    [
+        # 2-site Heisenberg
+        (couplings.heisenberg_coupling,
+         [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 2],
+         {"J": 1.0},
+         [1]),
+        # 3-site chiral
+        (couplings.chiral_3spin_coupling,
+         [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 3],
+         {"chi": 1.0},
+         [1, 2]),
+        # 2-site AKLT
+        (couplings.aklt_coupling,
+         [lambda backend: [sites.SpinSite(S=1, conserve='None', backend=backend)] * 2],
+         {"J": 1.0},
+         [1]),
+        # 2-site clock
+        # (couplings.clock_clock_coupling,
+        #  [lambda backend: [sites.ClockSite(3, conserve='None', backend=backend)] * 2],
+        #  {"Jx": 1.0, "Jz": 1.0},
+        #  [1]),
+    ]
+)
+def test_identity_insertion_parametrized(block_backend, coupling_factory, site_args, coupling_kwargs, valid_positions):
+    backend = backends.get_backend(block_backend=block_backend)
+    sites_list = site_args[0](backend)
+    coupling = coupling_factory(sites_list, **coupling_kwargs)
+    orig_num_sites = len(coupling.sites)
+    orig_num_factors = len(coupling.factorization)
+    orig_hash = coupling.to_hash()
+
+    for pos in valid_positions:
+        new_coupling = coupling.insert_identity_between_sites(position=pos)
+        # Number of sites should remain the same
+        assert len(new_coupling.sites) == orig_num_sites + 1
+        # Number of factors should increase by 1
+        assert len(new_coupling.factorization) == orig_num_factors + 1
+        # Hash should change
+        assert new_coupling.to_hash() != orig_hash
+
+    # Test invalid positions
+    for invalid_pos in [0, -1, orig_num_factors + 2]:
+        with pytest.raises(ValueError):
+            coupling.insert_identity_between_sites(position=invalid_pos)
+
+    @pytest.mark.parametrize(
+        "coupling_factory,site_args,coupling_kwargs,valid_positions",
+        [
+            # 2-site Heisenberg
+            (couplings.heisenberg_coupling,
+             [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 2],
+             {"J": 1.0},
+             [1]),
+            # 3-site chiral
+            (couplings.chiral_3spin_coupling,
+             [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 3],
+             {"chi": 1.0},
+             [1, 2]),
+            # 2-site AKLT
+            (couplings.aklt_coupling,
+             [lambda backend: [sites.SpinSite(S=1, conserve='None', backend=backend)] * 2],
+             {"J": 1.0},
+             [1]),
+            # 2-site clock
+            # (couplings.clock_clock_coupling,
+            #  [lambda backend: [sites.ClockSite(3, conserve='None', backend=backend)] * 2],
+            #  {"Jx": 1.0, "Jz": 1.0},
+            #  [1]),
+        ]
+    )
+    def test_identity_insertion_parametrized(block_backend, coupling_factory, site_args, coupling_kwargs, valid_positions):
+        backend = backends.get_backend(block_backend=block_backend)
+        sites_list = site_args[0](backend)
+        coupling = coupling_factory(sites_list, **coupling_kwargs)
+        orig_num_sites = len(coupling.sites)
+        orig_num_factors = len(coupling.factorization)
+        orig_hash = coupling.to_hash()
+
+        for pos in valid_positions:
+            new_coupling = coupling.insert_identity_between_sites(position=pos)
+            # Number of sites should remain the same
+            assert len(new_coupling.sites) == orig_num_sites
+            # Number of factors should increase by 1
+            assert len(new_coupling.factorization) == orig_num_factors + 1
+            # Hash should change
+            assert new_coupling.to_hash() != orig_hash
+
+        # Test invalid positions
+        for invalid_pos in [0, -1, orig_num_factors + 2]:
+            with pytest.raises(ValueError):
+                coupling.insert_identity_between_sites(position=invalid_pos)
+
+
+# def test_coupling_identity_insertion():
+#     """Test that inserting identity between sites creates a different hash."""
+#
+#
+#     spin_site = SpinSite(S=0.5, conserve='Sz')
+#
+#     coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+#     coupling_with_id = coupling.insert_identity_between_sites(1)
+#
+#     hash_original = coupling.to_hash()
+#     hash_with_id = coupling_with_id.to_hash()
+#
+#     assert hash_original != hash_with_id
+#     assert len(coupling_with_id.factorization) == len(coupling.factorization) + 1
+#     assert len(coupling_with_id.sites) == len(coupling.sites)+1
+
+
+def test_coupling_graph_structure():
+    """Test that building a graph using coupling hashes works.
+
+    """
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+
+    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+    coupling_hash = coupling.to_hash()
+
+    graph = [{} for _ in range(2)]
+
+    factorization = coupling.factorization
+
+    for local_idx, tensor in enumerate(factorization):
+        tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
+        tensor_np = tensor.to_numpy()
+
+        chiL = tensor_np.shape[0]
+        chiR = tensor_np.shape[1]
+
+        for jL in range(chiL):
+            keyL = ('coupling', coupling_hash, local_idx, jL)
+            for jR in range(chiR):
+                keyR = ('coupling', coupling_hash, local_idx, jR)
+                op = tensor_np[jL, jR, :, :]
+                if op is not None and len(op.shape) >= 2:
+                    norm_sq = float((op.real * op.real + op.imag * op.imag).sum())
+                    norm_val = norm_sq**0.5
+                    if norm_val > 1e-12:
+                        graph[local_idx][(keyL, keyR)] = op
+
+    assert len(graph) == 2
+
+    hash_keys_found = set()
+    for site_graph in graph:
+        for keyL, keyR in site_graph.keys():
+            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
+                hash_keys_found.add(keyL[1])
+
+    assert coupling_hash in hash_keys_found
+
+
+def test_coupling_graph_from_multiple_couplings():
+    """Test building a graph from multiple couplings with unique hash keys."""
+    try:
+        from cyten.models.sites import SpinSite
+        from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
+        from cyten.tensors import permute_legs
+    except ImportError:
+        pytest.skip('cyten not available')
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+
+    coupling1 = heisenberg_coupling([spin_site, spin_site], J=1.0)
+    coupling2 = heisenberg_coupling([spin_site, spin_site], J=2.0)
+    coupling3 = spin_field_coupling([spin_site], hz=0.5)
+
+    couplings = [coupling1, coupling2, coupling3]
+    hashes = [c.to_hash() for c in couplings]
+
+    assert len(set(hashes)) == 3
+
+    L = 4
+    graph = [{} for _ in range(L)]
+
+    for coupling_idx, coupling in enumerate(couplings):
+        coupling_hash = coupling.to_hash()
+        factorization = coupling.factorization
+
+        for local_idx, tensor in enumerate(factorization):
+            site_idx = local_idx % L
+
+            tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
+            tensor_np = tensor.to_numpy()
+
+            chiL = tensor_np.shape[0]
+            chiR = tensor_np.shape[1]
+
+            for jL in range(chiL):
+                keyL = ('coupling', coupling_hash, local_idx, jL)
+                for jR in range(chiR):
+                    keyR = ('coupling', coupling_hash, local_idx, jR)
+                    op = tensor_np[jL, jR, :, :]
+                    if op is not None and len(op.shape) >= 2 and op.shape[0] > 1:
+                        graph[site_idx][(keyL, keyR)] = op
+
+    all_hashes_in_graph = set()
+    for site_graph in graph:
+        for keyL, keyR in site_graph.keys():
+            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
+                all_hashes_in_graph.add(keyL[1])
+
+    for h in hashes:
+        assert h in all_hashes_in_graph
+
+
+def test_coupling_to_graph_keys():
+    """Test that coupling data is correctly converted to graph key-value structure."""
+    try:
+        from cyten.models.sites import SpinSite
+        from cyten.models.couplings import heisenberg_coupling
+        from cyten.tensors import permute_legs
+    except ImportError:
+        pytest.skip('cyten not available')
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+
+    coupling_hash = coupling.to_hash()
+    factorization = coupling.factorization
+
+    assert len(factorization) == 2
+
+    all_keys = []
+    all_values = []
+
+    for local_idx, tensor in enumerate(factorization):
+        tensor_permuted = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
+        tensor_np = tensor_permuted.to_numpy()
+
+        chiL = tensor_np.shape[0]
+        chiR = tensor_np.shape[1]
+
+        for jL in range(chiL):
+            keyL = ('coupling', coupling_hash, local_idx, jL)
+            for jR in range(chiR):
+                keyR = ('coupling', coupling_hash, local_idx, jR)
+                op = tensor_np[jL, jR, :, :]
+
+                all_keys.append((keyL, keyR))
+                all_values.append(op)
+
+    assert len(all_keys) > 0
+    assert len(all_keys) == len(all_values)
+
+    hash_from_keys = set()
+    for keyL, keyR in all_keys:
+        if keyL[0] == 'coupling':
+            hash_from_keys.add(keyL[1])
+
+    assert coupling_hash in hash_from_keys
+
+
+def test_mpograph_coupling_keys_with_tenpy():
+    """Test the structure of keys that MPOGraph.add_coupling_as_term creates.
+
+    This test requires tenpy to be available. It will be skipped if tenpy
+    cannot be imported.
+    """
+    try:
+        from tenpy.networks import mpo
+        from tenpy.networks import site as tenpy_site
+    except ImportError:
+        pytest.skip('tenpy.networks not available')
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+
+    coupling_hash = coupling.to_hash()
+
+    tenpy_sites = [tenpy_site.SpinHalfSite(conserve='Sz', sort_charge=False) for _ in range(4)]
+    graph = mpo.MPOGraph(tenpy_sites, bc='finite', unit_cell_width=4)
+
+    graph.add_coupling_as_term(coupling)
+
+    coupling_keys = []
+    for site_graph in graph.graph:
+        for keyL in site_graph.keys():
+            if isinstance(keyL, tuple) and len(keyL) >= 2 and keyL[0] == 'coupling':
+                coupling_keys.append(keyL)
+
+    assert len(coupling_keys) > 0
+
+    for key in coupling_keys:
+        assert key[0] == 'coupling'
+        assert key[1] == coupling_hash
+
+
+def test_coupling_identity_string_mimic():
+    """Test that we can build identity strings for couplings.
+    """
+    try:
+        from cyten.models.sites import SpinSite
+        from cyten.models.couplings import heisenberg_coupling
+        from cyten.tensors import permute_legs
+    except ImportError:
+        pytest.skip('cyten not available')
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+
+    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+    coupling_with_id = coupling.insert_identity_between_sites(1)
+
+    assert len(coupling_with_id.factorization) == len(coupling.factorization) + 1
+
+    coupling_hash = coupling_with_id.to_hash()
+    hash_key = ('coupling', coupling_hash)
+
+    L = 4
+    graph = [{} for _ in range(L)]
+    states = [set() for _ in range(L + 1)]
+
+    factorization = coupling_with_id.factorization
+    num_tensors = len(factorization)
+
+    for local_idx in range(num_tensors):
+        site_idx = local_idx % L
+        tensor = factorization[local_idx]
+        tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
+        tensor_np = tensor.to_numpy()
+
+        chiL = tensor_np.shape[0]
+        chiR = tensor_np.shape[1]
+
+        for jL in range(chiL):
+            for jR in range(chiR):
+                op = tensor_np[jL, jR, :, :]
+                norm_sq = float((op.real * op.real + op.imag * op.imag).sum())
+                norm_val = norm_sq**0.5
+                if norm_val < 1e-12:
+                    keyL = hash_key + (local_idx, jL)
+                    keyR = hash_key + (local_idx + 1, jR)
+                    if keyL not in graph[site_idx]:
+                        graph[site_idx][keyL] = {}
+                    graph[site_idx][keyL][keyR] = op
+                    states[site_idx].add(keyL)
+                    states[site_idx + 1].add(keyR)
+
+    assert len(graph) == L
+    assert len(states) == L + 1
+
+    hash_keys_in_graph = set()
+    for site_graph in graph:
+        for keyL in site_graph.keys():
+            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
+                hash_keys_in_graph.add(keyL[1])
+
+    assert coupling_hash in hash_keys_in_graph
+
+
+def test_coupling_string_methods_logic():
+    """Test add_coupling_string_left_to_right and add_coupling_string_right_to_left.
+    """
+    try:
+        from cyten.models.sites import SpinSite
+        from cyten.models.couplings import heisenberg_coupling
+    except ImportError:
+        pytest.skip('cyten not available')
+
+    spin_site = SpinSite(S=0.5, conserve='Sz')
+    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
+
+    coupling_hash = coupling.to_hash()
+    hash_key = ('coupling', coupling_hash)
+
+    start_key = ('coupling', coupling_hash, 0, 'start')
+
+    returned_keys = []
+
+    i, j = 0, 3
+    keyL = keyR = start_key
+    for k in range(i + 1, j):
+        if (k - i) % 4 == 0:
+            keyR = keyL + (k, hash_key, 'Id')
+        if not (keyL, keyR) in [(('a', 'b'), ('c', 'd'))]:
+            returned_keys.append((k, keyL, keyR))
+        keyL = keyR
+
+    assert len(returned_keys) == 2
+    assert returned_keys[0][0] == 1
+    assert returned_keys[1][0] == 2
+
+
+def test_add_missing_IdL_IdR_logic():
+    """Test add_missing_IdL_IdR for coupling hashes.
+    """
+    L = 4
+    graph = [{} for _ in range(L)]
+    states = [set() for _ in range(L + 1)]
+
+    graph[0][('IdL',)] = {('IdL',): [('Id', 1.0)]}
+    graph[2][('coupling', 'hash123')] = {('coupling', 'hash123'): [('op', 1.0)]}
+
+    insert_all_id = True
+    max_IdL = L
+    min_IdR = 0
+
+    for k in range(0, max_IdL):
+        if ('IdL', 'IdL') not in [(key, rkey) for key in graph[k] for rkey in graph[k][key]]:
+            if 'IdL' not in graph[k]:
+                graph[k]['IdL'] = {}
+            graph[k]['IdL']['IdL'] = [('Id', 1.0)]
+
+    for k in range(min_IdR, L):
+        if ('IdR', 'IdR') not in [(key, rkey) for key in graph[k] for rkey in graph[k][key]]:
+            if 'IdR' not in graph[k]:
+                graph[k]['IdR'] = {}
+            graph[k]['IdR']['IdR'] = [('Id', 1.0)]
+
+    assert ('IdL', 'IdL') in [(key, rkey) for key in graph[0] for rkey in graph[0][key]]
+    assert ('IdR', 'IdR') in [(key, rkey) for key in graph[3] for rkey in graph[3][key]]

--- a/tests/python_tests/models/test_couplings.py
+++ b/tests/python_tests/models/test_couplings.py
@@ -11,22 +11,12 @@ from numpy import testing as npt
 
 import cyten
 from cyten import SymmetryError, backends, tensors
+from cyten.symmetries import BraidChiralityUnspecifiedError
 from cyten.models import couplings, degrees_of_freedom, sites
-
-# from cyten.models.sites import SpinSite
-# from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
-#from tenpy.networks.mpo import MPO
 
 from cyten.models.sites import SpinSite
 from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
 from cyten.tensors import permute_legs
-
-try:
-    from sympy import S as sympy_S
-except ImportError:
-    sympy_S = None
-
-assert sympy_S is not None and callable(sympy_S), "sympy_S is not set correctly"
 
 def check_coupling(coupling_cls, site_num: int, invalid_site_nums: list[int], boson_fermion_mixing: bool, **kwargs):
     """Perform common checks that make sense for any coupling"""
@@ -677,213 +667,27 @@ def test_gold_coupling(block_backend):
     check_coupling(couplings.gold_coupling, site_num=2, invalid_site_nums=[1, 3], boson_fermion_mixing=False)
 
 
-# def test_insert_identity_between_sites(block_backend):
-#     """Test inserting identity tensors between sites in a coupling."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
-#     coupling.test_sanity()
-#
-#     for pos in [1, 2]:
-#         new_coupling = coupling.insert_identity_between_sites(position=pos)
-#
-#         assert len(new_coupling.sites) == len(coupling.sites)
-#         assert len(new_coupling.factorization) == len(coupling.factorization) + 1
-#
-#
-# def test_insert_identity_between_sites_invalid_position(block_backend):
-#     """Test that invalid positions raise errors."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.heisenberg_coupling([site, site], J=1.0)
-#
-#     with pytest.raises(ValueError, match='Position must be between'):
-#         coupling.insert_identity_between_sites(position=0)
-#
-#     with pytest.raises(ValueError, match='Position must be between'):
-#         coupling.insert_identity_between_sites(position=2)
-#
-#     with pytest.raises(ValueError, match='Position must be between'):
-#         coupling.insert_identity_between_sites(position=-1)
-#
-#
-# def test_insert_identity_between_sites_single_site(block_backend):
-#     """Test that inserting identity on single-site coupling fails."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.spin_field_coupling([site], hz=1.0)
-#
-#     with pytest.raises(ValueError, match='Position must be between'):
-#         coupling.insert_identity_between_sites(position=1)
-#
-#
-# def test_insert_identity_between_sites_different_backends(block_backend):
-#     """Test identity insertion with different backends using a 3-site spin coupling."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
-#
-#     for pos in [1, 2]:
-#         new_coupling = coupling.insert_identity_between_sites(position=pos)
-#         assert len(new_coupling.sites) == len(coupling.sites)
-#         assert len(new_coupling.factorization) == len(coupling.factorization) + 1
-
-
-# def test_coupling_hash_roundtrip(block_backend):
-#     """Test that to_hash and from_hash correctly roundtrip a coupling."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.heisenberg_coupling([site, site], J=1.0)
-#     coupling.test_sanity()
-#
-#     hash_str = coupling.to_hash()
-#     reconstructed = couplings.Coupling.from_hash(hash_str)
-#
-#     assert reconstructed.name == coupling.name
-#     assert len(reconstructed.sites) == len(coupling.sites)
-#     assert len(reconstructed.factorization) == len(coupling.factorization)
-#
-#     assert hash_str == reconstructed.to_hash()
-#
-#
-# def test_coupling_hash_3site(block_backend):
-#     """Test hash for 3-site couplings."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
-#     coupling.test_sanity()
-#
-#     hash_str = coupling.to_hash()
-#     reconstructed = couplings.Coupling.from_hash(hash_str)
-#
-#     assert reconstructed.name == coupling.name
-#     assert len(reconstructed.sites) == len(coupling.sites)
-#     assert len(reconstructed.factorization) == len(coupling.factorization)
-#     assert hash_str == reconstructed.to_hash()
-#
-#
-# def test_coupling_hash_with_identity(block_backend):
-#     """Test hash for couplings with identity inserted."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling = couplings.chiral_3spin_coupling([site, site, site], chi=1.0)
-#     coupling.test_sanity()
-#
-#     coupling_with_id = coupling.insert_identity_between_sites(position=1)
-#     hash_str = coupling_with_id.to_hash()
-#     reconstructed = couplings.Coupling.from_hash(hash_str)
-#
-#     assert reconstructed.name == coupling_with_id.name
-#     assert len(reconstructed.sites) == len(coupling_with_id.sites)
-#     assert len(reconstructed.factorization) == len(coupling_with_id.factorization)
-#     assert hash_str == reconstructed.to_hash()
-#
-#
-# def test_coupling_hash_deterministic(block_backend):
-#     """Test that hash is deterministic for same coupling."""
-#     backend = backends.get_backend(block_backend=block_backend)
-#     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
-#
-#     coupling1 = couplings.heisenberg_coupling([site, site], J=1.0)
-#     coupling2 = couplings.heisenberg_coupling([site, site], J=1.0)
-#
-#     hash1 = coupling1.to_hash()
-#     hash2 = coupling2.to_hash()
-#
-#     assert hash1 == hash2
-
-class SimpleTestGraph:
-    """Minimal mock MPO-like object for testing _make_graph_from_couplings."""
-
-    def __init__(self, L):
-        self.L = L
-        self._graph = None
-
-
-
 def test_coupling_hash_different_for_different_couplings(block_backend):
-    """Test that different couplings have different hashes."""
+    """Test that different couplings compare unequal.
+
+    Note: __hash__ is deliberately based on cheap *structural* metadata only (site types, tensor
+    shapes/legs/dtype -- see Coupling._key()), not on the tensors' floating-point values, so
+    couplings that only differ in their numeric content (like these two, same sites/shapes,
+    different J) are a legitimate same-hash collision; __eq__ (not __hash__) is what
+    distinguishes them, via the numeric almost_equal check. See test_coupling_eq_hash_numeric_closeness.
+    """
     backend = backends.get_backend(block_backend=block_backend)
     site = sites.SpinSite(S=0.5, conserve='None', backend=backend)
 
     coupling1 = couplings.heisenberg_coupling([site, site], J=1.0)
     coupling2 = couplings.heisenberg_coupling([site, site], J=2.0)
 
-    hash1 = coupling1.to_hash()
-    hash2 = coupling2.to_hash()
-
-    assert hash1 != hash2
+    assert coupling1 != coupling2
 
 
-def test_MPO_graph_from_couplings():
-    """Test building MPO graph from couplings using hashing."""
-
-    pytest.skip('Test currently depends on tenpy.')
-
-    L = 4
-    spin_sites = [SpinSite(S=0.5, conserve='Sz') for _ in range(L)]
-
-    coupling1 = heisenberg_coupling([spin_sites[0], spin_sites[1]], J=1.0)
-    coupling2 = heisenberg_coupling([spin_sites[0], spin_sites[1]], J=2.0)
-    coupling3 = spin_field_coupling([spin_sites[0]], hz=0.5)
-
-    couplings = [coupling1, coupling2, coupling3]
-
-    hashes = [c.to_hash() for c in couplings]
-    assert len(hashes) == len(couplings)
-    assert hashes[0] != hashes[1]
-    assert hashes[0] != hashes[2]
-
-    test_graph = SimpleTestGraph(L)
-
-    MPO._make_graph_from_couplings(test_graph, couplings)
-
-    assert test_graph._graph is not None
-    assert len(test_graph._graph) == L
-
-    for site_graph in test_graph._graph:
-        assert isinstance(site_graph, dict)
-
-
-def test_MPO_graph_from_couplings_identity_insertion():
-    """Test building MPO graph from cyten Couplings with identity insertion."""
-
-    pytest.skip('Test currently depends on tenpy.')
-
-    L = 4
-    spin_sites = [SpinSite(S=0.5, conserve='Sz') for _ in range(L)]
-
-    coupling = heisenberg_coupling([spin_sites[0], spin_sites[2]], J=1.0)
-
-    coupling_with_identity = coupling.insert_identity_between_sites(1)
-
-    assert len(coupling_with_identity.factorization) == len(coupling.factorization) + 1
-    assert len(coupling_with_identity.sites) == len(coupling.sites)
-
-    hash_original = coupling.to_hash()
-    hash_with_identity = coupling_with_identity.to_hash()
-    assert hash_original != hash_with_identity
-
-    couplings = [coupling_with_identity]
-
-    test_graph = SimpleTestGraph(L)
-
-    MPO._make_graph_from_couplings(test_graph, couplings)
-
-    assert test_graph._graph is not None
-    assert len(test_graph._graph) == L
-
-
-def test_MPO_graph_from_couplings_hash():
-    """Test that coupling hashing correctly identifies unique couplings."""
-
+def test_coupling_eq_hash_independent_construction():
+    """Test that Coupling equality/hashing correctly identifies structurally-equal couplings,
+    even when they are distinct Python objects built independently."""
 
     spin_site1 = SpinSite(S=0.5, conserve='Sz')
     spin_site2 = SpinSite(S=0.5, conserve='Sz')
@@ -895,25 +699,20 @@ def test_MPO_graph_from_couplings_hash():
     coupling_J2p = heisenberg_coupling([spin_site1, spin_site2], J=2.0)
     coupling_diff_J = spin_field_coupling([spin_site1], hz=0.5)
 
-    hash1 = coupling_J1.to_hash()
-    hash1p= coupling_J1p.to_hash()
+    assert coupling_J1 != coupling_J2
+    assert coupling_J1 != coupling_diff_J
+    assert coupling_J2 != coupling_diff_J
 
-    hash2 = coupling_J2.to_hash()
-    hash2p = coupling_J2p.to_hash()
-
-    hash3 = coupling_diff_J.to_hash()
-
-
-    assert hash1 != hash2
-    assert hash1 != hash3
-    assert hash2 != hash3
-
-    assert hash1p == hash1
-    assert hash2p == hash2
+    # distinct objects, identical content -> equal, and equal hash (required by the hash contract)
+    assert coupling_J1p == coupling_J1
+    assert coupling_J1p is not coupling_J1
+    assert hash(coupling_J1p) == hash(coupling_J1)
+    assert coupling_J2p == coupling_J2
+    assert hash(coupling_J2p) == hash(coupling_J2)
 
 
 def test_coupling_hashing():
-    """Test that coupling hashing correctly distinguishes different couplings."""
+    """Test that Coupling equality/hashing correctly distinguishes different couplings."""
 
     spin_site = SpinSite(S=0.5, conserve='Sz')
 
@@ -921,13 +720,46 @@ def test_coupling_hashing():
     coupling_J2 = heisenberg_coupling([spin_site, spin_site], J=2.0)
     coupling_spin_field = spin_field_coupling([spin_site], hz=0.5)
 
-    hash1 = coupling_J1.to_hash()
-    hash2 = coupling_J2.to_hash()
-    hash3 = coupling_spin_field.to_hash()
+    assert coupling_J1 != coupling_J2
+    assert coupling_J1 != coupling_spin_field
+    assert coupling_J2 != coupling_spin_field
 
-    assert hash1 != hash2
-    assert hash1 != hash3
-    assert hash2 != hash3
+
+def test_coupling_eq_hash_numeric_closeness():
+    """Coupling equality is exact structural + almost_equal numeric comparison of the
+    factorization tensors, so couplings must have both matching structure AND matching tensor
+    values (up to almost_equal's tolerance) to compare equal / share a hash bucket."""
+
+    site = SpinSite(S=0.5, conserve='None')
+
+    c1 = heisenberg_coupling([site, site], J=1.0)
+    c2 = heisenberg_coupling([site, site], J=1.0)
+    c3 = heisenberg_coupling([site, site], J=1.0 + 1e-3)  # different tensor values
+    c4 = spin_field_coupling([site], hz=0.5)  # different sites (1-site vs 2-site coupling)
+
+    # same object always equals itself
+    assert c1 == c1
+    # distinct objects, numerically identical (not merely `is`-equal) tensors -> equal
+    assert c1 == c2 and c1 is not c2
+    assert hash(c1) == hash(c2)
+
+    # same structure (site types, tensor shapes/legs), different tensor *values* -> not equal;
+    # this is a legitimate same-`_key()` collision that only the numeric `almost_equal` check in
+    # __eq__ (not `_key()`/`__hash__` alone) can distinguish
+    assert c1._key() == c3._key()
+    assert c1 != c3
+
+    # different sites/factorization shape entirely -> not equal (and _key() differs too)
+    assert c1._key() != c4._key()
+    assert c1 != c4
+
+    # usable as dict keys: structurally+numerically-equal couplings collapse to one entry
+    d = {c1: 'first'}
+    d[c2] = 'second'
+    assert len(d) == 1 and d[c1] == 'second'
+    d[c3] = 'third'
+    d[c4] = 'fourth'
+    assert len(d) == 3
 
 
 @pytest.mark.parametrize(
@@ -961,386 +793,357 @@ def test_identity_insertion_parametrized(block_backend, coupling_factory, site_a
     coupling = coupling_factory(sites_list, **coupling_kwargs)
     orig_num_sites = len(coupling.sites)
     orig_num_factors = len(coupling.factorization)
-    orig_hash = coupling.to_hash()
 
     for pos in valid_positions:
         new_coupling = coupling.insert_identity_between_sites(position=pos)
-        # Number of sites should remain the same
+        # Number of sites should increase by 1 (a copy of the left neighbor is inserted)
         assert len(new_coupling.sites) == orig_num_sites + 1
         # Number of factors should increase by 1
         assert len(new_coupling.factorization) == orig_num_factors + 1
-        # Hash should change
-        assert new_coupling.to_hash() != orig_hash
+        # structurally (and hence via __eq__/__hash__) distinct from the original
+        assert new_coupling != coupling
 
     # Test invalid positions
     for invalid_pos in [0, -1, orig_num_factors + 2]:
         with pytest.raises(ValueError):
             coupling.insert_identity_between_sites(position=invalid_pos)
 
-    @pytest.mark.parametrize(
-        "coupling_factory,site_args,coupling_kwargs,valid_positions",
-        [
-            # 2-site Heisenberg
-            (couplings.heisenberg_coupling,
-             [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 2],
-             {"J": 1.0},
-             [1]),
-            # 3-site chiral
-            (couplings.chiral_3spin_coupling,
-             [lambda backend: [sites.SpinSite(S=0.5, conserve='None', backend=backend)] * 3],
-             {"chi": 1.0},
-             [1, 2]),
-            # 2-site AKLT
-            (couplings.aklt_coupling,
-             [lambda backend: [sites.SpinSite(S=1, conserve='None', backend=backend)] * 2],
-             {"J": 1.0},
-             [1]),
-            # 2-site clock
-            # (couplings.clock_clock_coupling,
-            #  [lambda backend: [sites.ClockSite(3, conserve='None', backend=backend)] * 2],
-            #  {"Jx": 1.0, "Jz": 1.0},
-            #  [1]),
-        ]
+
+def test_identity_tensor_site():
+    """Test sites.identity_tensor: structural correctness and ValueError guard."""
+
+    site = SpinSite(S=0.5, conserve='Sz')
+    coupling = heisenberg_coupling([site, site])
+
+    # wL / wR are the co-domain-style representatives of the shared virtual bond;
+    # the coupling sanity guarantee ensures they are the same ElementarySpace.
+    wL = coupling.factorization[0].get_leg_co_domain('wR')
+    wR = coupling.factorization[1].get_leg_co_domain('wL')
+    assert wL == wR, 'coupling internal sanity: virtual bond spaces must match'
+
+    # --- overbraid=True (default) ---
+    tensor = sites.identity_tensor(site, wL, wR, overbraid=True)
+
+    assert tensor.labels == ['wL', 'p', 'wR', 'p*']
+    assert tensor.num_codomain_legs == 2
+    assert tensor.num_domain_legs == 2
+    assert tensor.get_leg_co_domain('p') == site.leg
+    assert tensor.get_leg_co_domain('p*') == site.leg
+    assert tensor.get_leg_co_domain('wL') == wL
+    assert tensor.get_leg_co_domain('wR') == wR
+    tensor.test_sanity()
+
+    # --- overbraid=False ---
+    # For a group symmetry (U(1)) braiding is symmetric, so the result is the same tensor.
+    tensor_under = sites.identity_tensor(site, wL, wR, overbraid=False)
+    assert tensor_under.labels == ['wL', 'p', 'wR', 'p*']
+    tensor_under.test_sanity()
+
+    # --- ValueError: wR != wL ---
+    # The first block's wL is the trivial (1-D) boundary space, which differs from the bond.
+    trivial_space = coupling.factorization[0].get_leg_co_domain('wL')
+    assert trivial_space != wL, 'trivial boundary space must differ from the bond space'
+    with pytest.raises(ValueError):
+        sites.identity_tensor(site, wL, trivial_space)
+
+    # --- Non-trivial physical leg: spin-1 site, same bond ---
+    site_s1 = SpinSite(S=1.0, conserve='Sz')
+    coupling_s1 = heisenberg_coupling([site_s1, site_s1])
+    wL_s1 = coupling_s1.factorization[0].get_leg_co_domain('wR')
+    wR_s1 = coupling_s1.factorization[1].get_leg_co_domain('wL')
+    tensor_s1 = sites.identity_tensor(site_s1, wL_s1, wR_s1)
+    assert tensor_s1.get_leg_co_domain('p') == site_s1.leg
+    tensor_s1.test_sanity()
+
+
+def test_insert_identity_between_sites():
+    # insert_identity_between_sites(position) does not take an explicit site to insert: it
+    # auto-derives the inserted site as sites[position - 1] (the left neighbor), and requires
+    # sites[position - 1].leg == sites[position].leg.
+
+    # ------------------------------------------------------------------ structure
+    site_a = SpinSite(S=0.5, conserve='Sz')
+    site_b = SpinSite(S=0.5, conserve='Sz')
+    original = heisenberg_coupling([site_a, site_b])
+
+    result = original.insert_identity_between_sites(1)
+
+    assert len(result.sites) == 3
+    assert len(result.factorization) == 3
+    assert result.sites[0] is site_a
+    assert result.sites[1] is site_a  # auto-derived: the left neighbor of the insertion point
+    assert result.sites[2] is site_b
+    # The inserted tensor must carry the right labels..
+    assert result.factorization[1].labels == ['wL', 'p', 'wR', 'p*']
+    result.test_sanity()
+
+    with pytest.raises(ValueError):
+        original.insert_identity_between_sites(0)   # position=0 is out of range
+    with pytest.raises(ValueError):
+        original.insert_identity_between_sites(2)   # position=len(sites) is out of range
+
+    # sites with different physical legs are rejected
+    site_half_ns = SpinSite(S=0.5, conserve='None')
+    site_one_ns = SpinSite(S=1.0, conserve='None')
+    mixed = couplings.Coupling(
+        sites=[site_half_ns, site_one_ns],
+        factorization=heisenberg_coupling([site_half_ns, site_half_ns]).factorization,
+        skip_sanity=True,
     )
-    def test_identity_insertion_parametrized(block_backend, coupling_factory, site_args, coupling_kwargs, valid_positions):
-        backend = backends.get_backend(block_backend=block_backend)
-        sites_list = site_args[0](backend)
-        coupling = coupling_factory(sites_list, **coupling_kwargs)
-        orig_num_sites = len(coupling.sites)
-        orig_num_factors = len(coupling.factorization)
-        orig_hash = coupling.to_hash()
+    with pytest.raises(ValueError):
+        mixed.insert_identity_between_sites(1)
 
-        for pos in valid_positions:
-            new_coupling = coupling.insert_identity_between_sites(position=pos)
-            # Number of sites should remain the same
-            assert len(new_coupling.sites) == orig_num_sites
-            # Number of factors should increase by 1
-            assert len(new_coupling.factorization) == orig_num_factors + 1
-            # Hash should change
-            assert new_coupling.to_hash() != orig_hash
+    # ------------------------------------------------------------------ content check (NoSymmetry)
+    # For a coupling C2 on [s0, s1] (same site s0 == s1 == site_half_ns), inserting an identity
+    # at position 1 produces a 3-site coupling C3 satisfying:
+    #   C3[p0, pi, p1, p1*, pi*, p0*] = C2[p0, p1, p1*, p0*] * delta(pi, pi*)
+    #
+    # Numpy leg order (domain labels are stored reversed in the label list):
+    #   C2: [p0, p1, p1*, p0*]  → shape [d0, d1, d1, d0]
+    #   C3: [p0, pi, p1, p1*, pi*, p0*] → shape [d0, di, d1, d1, di, d0]
+    original_ns = heisenberg_coupling([site_half_ns, site_half_ns])
+    result_ns = original_ns.insert_identity_between_sites(1)
+    assert result_ns.sites[1] is site_half_ns
+    result_ns.test_sanity()
 
-        # Test invalid positions
-        for invalid_pos in [0, -1, orig_num_factors + 2]:
-            with pytest.raises(ValueError):
-                coupling.insert_identity_between_sites(position=invalid_pos)
+    C2 = original_ns.to_numpy(understood_braiding=True)   # [d0, d1, d1, d0]
+    C3 = result_ns.to_numpy(understood_braiding=True)      # [d0, di, d1, d1, di, d0]
 
+    di = site_half_ns.dim   # 2 for spin-1/2
+    assert C3.shape == (C2.shape[0], di, C2.shape[1], C2.shape[2], di, C2.shape[3])
 
-# def test_coupling_identity_insertion():
-#     """Test that inserting identity between sites creates a different hash."""
-#
-#
-#     spin_site = SpinSite(S=0.5, conserve='Sz')
-#
-#     coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-#     coupling_with_id = coupling.insert_identity_between_sites(1)
-#
-#     hash_original = coupling.to_hash()
-#     hash_with_id = coupling_with_id.to_hash()
-#
-#     assert hash_original != hash_with_id
-#     assert len(coupling_with_id.factorization) == len(coupling.factorization) + 1
-#     assert len(coupling_with_id.sites) == len(coupling.sites)+1
+    for pi in range(di):
+        # Diagonal block: matches original coupling.
+        np.testing.assert_allclose(C3[:, pi, :, :, pi, :], C2, atol=1e-13,
+                                   err_msg=f'diagonal block pi={pi} does not match original coupling')
+    for pi in range(di):
+        for pi_star in range(di):
+            if pi != pi_star:
+                # Off-diagonal blocks: must vanish (identity in physical space).
+                np.testing.assert_allclose(C3[:, pi, :, :, pi_star, :], 0, atol=1e-13,
+                                           err_msg=f'off-diagonal block pi={pi}, pi*={pi_star} is non-zero')
 
 
-def test_coupling_graph_structure():
-    """Test that building a graph using coupling hashes works.
 
+def test_adjacent_transpositions():
+    """_adjacent_transpositions must realize every permutation via adjacent swaps."""
+    import itertools
+
+    for n in range(1, 5):
+        for perm in itertools.permutations(range(n)):
+            perm = list(perm)
+            swap_positions = couplings._adjacent_transpositions(perm)
+            working = list(range(n))
+            for pos in swap_positions:
+                working[pos], working[pos + 1] = working[pos + 1], working[pos]
+            assert working == perm
+
+
+def _to_matrix(dense, dims):
+    """Convert a dense block with axes [p0,...,p(n-1), p(n-1)*,...,p0*] (bra reversed, as
+    returned by Coupling.to_tensor().to_numpy()) into a plain (prod(dims), prod(dims)) matrix
+    with row = ket multi-index, column = bra multi-index, both in normal (non-reversed) order.
+    """
+    n = len(dims)
+    bra_axes_reversed = list(range(n, 2 * n))
+    normal_order = list(range(n)) + bra_axes_reversed[::-1]
+    dense = np.transpose(dense, normal_order)
+    dim = int(np.prod(dims))
+    return dense.reshape(dim, dim)
+
+
+def _permute_matrix(mat, dims, permutation):
+    """Conjugate a matrix (as returned by `_to_matrix`) by the basis permutation that reorders
+    the `len(dims)` tensor factors according to `permutation`."""
+    n = len(dims)
+    new_dims = [dims[i] for i in permutation]
+    mat_tensor = mat.reshape(tuple(dims) + tuple(dims))
+    axes = list(permutation) + [n + i for i in permutation]
+    mat_tensor = np.transpose(mat_tensor, axes)
+    dim = int(np.prod(new_dims))
+    return mat_tensor.reshape(dim, dim)
+
+
+def _random_hermitian_coupling(sites, seed):
+    """A coupling with a random Hermitian dense block, for NoSymmetry sites."""
+    dims = [s.dim for s in sites]
+    rng = np.random.default_rng(seed)
+    shape = tuple(dims) + tuple(dims[::-1])
+    block = rng.normal(size=shape) + 1j * rng.normal(size=shape)
+    dim = int(np.prod(dims))
+    mat = block.reshape(dim, dim)
+    mat = mat + mat.conj().T
+    return couplings.Coupling.from_dense_block(mat.reshape(shape), sites, name='random', understood_braiding=True)
+
+
+def test_coupling_permute():
+    """Coupling.permute should reorder the sites/operator like conjugating by a basis
+    permutation, cache repeated requests, and correctly track `_levels`."""
+    site_dims = [0.5, 1.0, 1.5, 2.0]
+    sites = [SpinSite(S=S, conserve=None) for S in site_dims]
+    dims = [s.dim for s in sites]
+    coupling = _random_hermitian_coupling(sites, seed=1234)
+
+    assert coupling._levels == [1, 2, 3, 4]
+    assert coupling._permuted == []
+
+    permutation = [2, 3, 0, 1]
+    levels = [1, 2, 3, 4]
+    swap_positions = couplings._adjacent_transpositions(permutation)
+    over_braid = [None] * len(swap_positions)  # auto-derive chirality from `levels`
+
+    result = coupling.permute(permutation, levels, over_braid)
+    result.test_sanity()
+
+    # structure: sites reordered as expected
+    assert [s.dim for s in result.sites] == [dims[i] for i in permutation]
+    # _levels: tracks which original level ended up where
+    assert result._levels == [coupling._levels[i] for i in permutation]
+    # a freshly permuted coupling starts with its own, empty cache
+    assert result._permuted == []
+
+    # value check: equivalent to conjugating the dense operator by the basis permutation
+    H_mat = _to_matrix(coupling.to_tensor().to_numpy(understood_braiding=True), dims)
+    expected_mat = _permute_matrix(H_mat, dims, permutation)
+    new_dims = [dims[i] for i in permutation]
+    result_mat = _to_matrix(result.to_tensor().to_numpy(understood_braiding=True), new_dims)
+    np.testing.assert_allclose(result_mat, expected_mat, atol=1e-10)
+
+    # caching: same permutation returns the cached object, even with different levels/over_braid
+    result_again = coupling.permute(permutation, [9, 9, 9, 9], [None] * len(swap_positions))
+    assert result_again is result
+    assert len(coupling._permuted) == 1
+
+    # a different permutation triggers a new computation and a new cache entry
+    other_permutation = [1, 0, 2, 3]
+    other_result = coupling.permute(other_permutation, levels, [None])
+    assert other_result is not result
+    assert len(coupling._permuted) == 2
+
+
+def test_coupling_permute_identity():
+    """Permuting with the identity permutation (0 swaps) should reproduce the same operator."""
+    sites = [SpinSite(S=S, conserve=None) for S in (0.5, 1.0, 1.5)]
+    dims = [s.dim for s in sites]
+    coupling = _random_hermitian_coupling(sites, seed=5)
+
+    result = coupling.permute([0, 1, 2], [1, 2, 3], [])
+    assert [s is s2 for s, s2 in zip(result.sites, coupling.sites)] == [True, True, True]
+    H_mat = _to_matrix(coupling.to_tensor().to_numpy(understood_braiding=True), dims)
+    result_mat = _to_matrix(result.to_tensor().to_numpy(understood_braiding=True), dims)
+    np.testing.assert_allclose(result_mat, H_mat, atol=1e-10)
+
+
+def test_coupling_permute_errors():
+    """Coupling.permute should raise clear errors for invalid input."""
+    sites = [SpinSite(S=S, conserve=None) for S in (0.5, 1.0, 1.5, 2.0)]
+    coupling = _random_hermitian_coupling(sites, seed=99)
+    levels = [1, 2, 3, 4]
+
+    with pytest.raises(ValueError):
+        coupling.permute([0, 1, 2, 2], levels, [None] * 10)  # not a valid permutation
+
+    with pytest.raises(ValueError):
+        # permutation [1, 0, 2, 3] needs exactly 1 adjacent swap
+        coupling.permute([1, 0, 2, 3], levels, [None, None])
+
+    with pytest.raises(BraidChiralityUnspecifiedError):
+        # two sites that must braid (adjacent swap) with equal levels: chirality is ambiguous
+        coupling.permute([1, 0, 3, 2], [5, 5, 7, 7], [None, None])
+
+
+def _asym_hopping_dense_block(site):
+    """Dense block [p0,p1,p1*,p0*] for the (non-Hermitian) 2-site term ``Cd_0 C_1`` (or the
+    bosonic analogue ``Bd_0 B_1``), correctly JW-dressed as in
+    :func:`~cyten.models.couplings._quadratic_coupling_numpy`: the *first* (left) operand carries
+    the JW-string factor.
+    """
+    creator = site.get_creator_numpy(species=0, include_JW=True)
+    annihilator = site.get_annihilator_numpy(species=0, include_JW=True)
+    return (creator @ site._JW)[:, None, None, :] * annihilator[None, :, :, None]
+
+
+@pytest.mark.parametrize(
+    'site_factory,label',
+    [
+        (lambda: sites.SpinlessBosonSite(Nmax=1, conserve='N'), 'boson'),
+        (lambda: sites.SpinlessFermionSite(num_species=1, conserve='N'), 'fermion'),
+    ],
+)
+def test_coupling_permute_matches_direct_permute_legs(site_factory, label):
+    """Verify that `Coupling.permute` produces the exact same results as permuting the
+    fully-contracted tensor directly.
+
+    Internally, `Coupling.permute` follows this exact chain:
+    contract -> permute_legs -> relabel -> re-factorize.
+
+    This test ensures that this entire re-factorization round-trip works perfectly
+    without losing or duplicating any data. It checks this behavior for both
+    fermionic and bosonic sites.
+    """
+    site = site_factory()
+    coupling = couplings.Coupling.from_dense_block(
+        _asym_hopping_dense_block(site), [site, site], understood_braiding=True
+    )
+
+    over = True
+    permuted = coupling.permute([1, 0], levels=[1, 2], over_braid=[over])
+
+    codomain_labels, domain_labels = ['p0', 'p1'], ['p0*', 'p1*']
+    level_dict = {
+        codomain_labels[0]: 1 if over else 0,
+        domain_labels[0]: 1 if over else 0,
+        codomain_labels[1]: 0 if over else 1,
+        domain_labels[1]: 0 if over else 1,
+    }
+    tensor_direct = permute_legs(
+        coupling.to_tensor(), codomain=['p1', 'p0'], domain=['p1*', 'p0*'], levels=level_dict
+    )
+    # relabel to the same p{new_pos} convention Coupling.permute uses (site formerly at 1 is now p0)
+    tensor_direct = tensor_direct.relabel({'p0': 'q1', 'p1': 'q0', 'p0*': 'q1*', 'p1*': 'q0*'})
+    tensor_direct = tensor_direct.relabel({'q0': 'p0', 'q1': 'p1', 'q0*': 'p0*', 'q1*': 'p1*'})
+
+    labels = ['p0', 'p1', 'p0*', 'p1*']
+    dim_permuted = permuted.to_tensor().to_numpy(labels, understood_braiding=True)
+    dim_direct = tensor_direct.to_numpy(labels, understood_braiding=True)
+    np.testing.assert_allclose(dim_permuted, dim_direct, atol=1e-10, err_msg=label)
+
+
+@pytest.mark.parametrize(
+    'site_factory,expected_sign,label',
+    [
+        (lambda: sites.SpinlessBosonSite(Nmax=1, conserve='N'), +1, 'boson'),
+        (lambda: sites.SpinlessFermionSite(num_species=1, conserve='N'), -1, 'fermion'),
+    ],
+)
+def test_coupling_permute_exchange_sign(site_factory, expected_sign, label):
+    """
+    Returns the exchange sign for Coupling.permute (negative for fermions, positive for bosons).
+
+    This checks the physical sign by comparing the permuted coupling against a new
+    coupling built from scratch with reversed site order.
     """
 
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-
-    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-    coupling_hash = coupling.to_hash()
-
-    graph = [{} for _ in range(2)]
-
-    factorization = coupling.factorization
-
-    for local_idx, tensor in enumerate(factorization):
-        tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
-        tensor_np = tensor.to_numpy()
-
-        chiL = tensor_np.shape[0]
-        chiR = tensor_np.shape[1]
-
-        for jL in range(chiL):
-            keyL = ('coupling', coupling_hash, local_idx, jL)
-            for jR in range(chiR):
-                keyR = ('coupling', coupling_hash, local_idx, jR)
-                op = tensor_np[jL, jR, :, :]
-                if op is not None and len(op.shape) >= 2:
-                    norm_sq = float((op.real * op.real + op.imag * op.imag).sum())
-                    norm_val = norm_sq**0.5
-                    if norm_val > 1e-12:
-                        graph[local_idx][(keyL, keyR)] = op
-
-    assert len(graph) == 2
-
-    hash_keys_found = set()
-    for site_graph in graph:
-        for keyL, keyR in site_graph.keys():
-            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
-                hash_keys_found.add(keyL[1])
-
-    assert coupling_hash in hash_keys_found
-
-
-def test_coupling_graph_from_multiple_couplings():
-    """Test building a graph from multiple couplings with unique hash keys."""
-    try:
-        from cyten.models.sites import SpinSite
-        from cyten.models.couplings import heisenberg_coupling, spin_field_coupling
-        from cyten.tensors import permute_legs
-    except ImportError:
-        pytest.skip('cyten not available')
-
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-
-    coupling1 = heisenberg_coupling([spin_site, spin_site], J=1.0)
-    coupling2 = heisenberg_coupling([spin_site, spin_site], J=2.0)
-    coupling3 = spin_field_coupling([spin_site], hz=0.5)
-
-    couplings = [coupling1, coupling2, coupling3]
-    hashes = [c.to_hash() for c in couplings]
-
-    assert len(set(hashes)) == 3
-
-    L = 4
-    graph = [{} for _ in range(L)]
-
-    for coupling_idx, coupling in enumerate(couplings):
-        coupling_hash = coupling.to_hash()
-        factorization = coupling.factorization
-
-        for local_idx, tensor in enumerate(factorization):
-            site_idx = local_idx % L
-
-            tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
-            tensor_np = tensor.to_numpy()
-
-            chiL = tensor_np.shape[0]
-            chiR = tensor_np.shape[1]
-
-            for jL in range(chiL):
-                keyL = ('coupling', coupling_hash, local_idx, jL)
-                for jR in range(chiR):
-                    keyR = ('coupling', coupling_hash, local_idx, jR)
-                    op = tensor_np[jL, jR, :, :]
-                    if op is not None and len(op.shape) >= 2 and op.shape[0] > 1:
-                        graph[site_idx][(keyL, keyR)] = op
-
-    all_hashes_in_graph = set()
-    for site_graph in graph:
-        for keyL, keyR in site_graph.keys():
-            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
-                all_hashes_in_graph.add(keyL[1])
-
-    for h in hashes:
-        assert h in all_hashes_in_graph
-
-
-def test_coupling_to_graph_keys():
-    """Test that coupling data is correctly converted to graph key-value structure."""
-    try:
-        from cyten.models.sites import SpinSite
-        from cyten.models.couplings import heisenberg_coupling
-        from cyten.tensors import permute_legs
-    except ImportError:
-        pytest.skip('cyten not available')
-
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-
-    coupling_hash = coupling.to_hash()
-    factorization = coupling.factorization
-
-    assert len(factorization) == 2
-
-    all_keys = []
-    all_values = []
-
-    for local_idx, tensor in enumerate(factorization):
-        tensor_permuted = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
-        tensor_np = tensor_permuted.to_numpy()
-
-        chiL = tensor_np.shape[0]
-        chiR = tensor_np.shape[1]
-
-        for jL in range(chiL):
-            keyL = ('coupling', coupling_hash, local_idx, jL)
-            for jR in range(chiR):
-                keyR = ('coupling', coupling_hash, local_idx, jR)
-                op = tensor_np[jL, jR, :, :]
-
-                all_keys.append((keyL, keyR))
-                all_values.append(op)
-
-    assert len(all_keys) > 0
-    assert len(all_keys) == len(all_values)
-
-    hash_from_keys = set()
-    for keyL, keyR in all_keys:
-        if keyL[0] == 'coupling':
-            hash_from_keys.add(keyL[1])
-
-    assert coupling_hash in hash_from_keys
-
-
-def test_mpograph_coupling_keys_with_tenpy():
-    """Test the structure of keys that MPOGraph.add_coupling_as_term creates.
-
-    This test requires tenpy to be available. It will be skipped if tenpy
-    cannot be imported.
-    """
-    try:
-        from tenpy.networks import mpo
-        from tenpy.networks import site as tenpy_site
-    except ImportError:
-        pytest.skip('tenpy.networks not available')
-
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-
-    coupling_hash = coupling.to_hash()
-
-    tenpy_sites = [tenpy_site.SpinHalfSite(conserve='Sz', sort_charge=False) for _ in range(4)]
-    graph = mpo.MPOGraph(tenpy_sites, bc='finite', unit_cell_width=4)
-
-    graph.add_coupling_as_term(coupling)
-
-    coupling_keys = []
-    for site_graph in graph.graph:
-        for keyL in site_graph.keys():
-            if isinstance(keyL, tuple) and len(keyL) >= 2 and keyL[0] == 'coupling':
-                coupling_keys.append(keyL)
-
-    assert len(coupling_keys) > 0
-
-    for key in coupling_keys:
-        assert key[0] == 'coupling'
-        assert key[1] == coupling_hash
-
-
-def test_coupling_identity_string_mimic():
-    """Test that we can build identity strings for couplings.
-    """
-    try:
-        from cyten.models.sites import SpinSite
-        from cyten.models.couplings import heisenberg_coupling
-        from cyten.tensors import permute_legs
-    except ImportError:
-        pytest.skip('cyten not available')
-
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-
-    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-    coupling_with_id = coupling.insert_identity_between_sites(1)
-
-    assert len(coupling_with_id.factorization) == len(coupling.factorization) + 1
-
-    coupling_hash = coupling_with_id.to_hash()
-    hash_key = ('coupling', coupling_hash)
-
-    L = 4
-    graph = [{} for _ in range(L)]
-    states = [set() for _ in range(L + 1)]
-
-    factorization = coupling_with_id.factorization
-    num_tensors = len(factorization)
-
-    for local_idx in range(num_tensors):
-        site_idx = local_idx % L
-        tensor = factorization[local_idx]
-        tensor = permute_legs(tensor, codomain=['wL', 'wR'], domain=['p', 'p*'])
-        tensor_np = tensor.to_numpy()
-
-        chiL = tensor_np.shape[0]
-        chiR = tensor_np.shape[1]
-
-        for jL in range(chiL):
-            for jR in range(chiR):
-                op = tensor_np[jL, jR, :, :]
-                norm_sq = float((op.real * op.real + op.imag * op.imag).sum())
-                norm_val = norm_sq**0.5
-                if norm_val < 1e-12:
-                    keyL = hash_key + (local_idx, jL)
-                    keyR = hash_key + (local_idx + 1, jR)
-                    if keyL not in graph[site_idx]:
-                        graph[site_idx][keyL] = {}
-                    graph[site_idx][keyL][keyR] = op
-                    states[site_idx].add(keyL)
-                    states[site_idx + 1].add(keyR)
-
-    assert len(graph) == L
-    assert len(states) == L + 1
-
-    hash_keys_in_graph = set()
-    for site_graph in graph:
-        for keyL in site_graph.keys():
-            if isinstance(keyL, tuple) and keyL[0] == 'coupling':
-                hash_keys_in_graph.add(keyL[1])
-
-    assert coupling_hash in hash_keys_in_graph
-
-
-def test_coupling_string_methods_logic():
-    """Test add_coupling_string_left_to_right and add_coupling_string_right_to_left.
-    """
-    try:
-        from cyten.models.sites import SpinSite
-        from cyten.models.couplings import heisenberg_coupling
-    except ImportError:
-        pytest.skip('cyten not available')
-
-    spin_site = SpinSite(S=0.5, conserve='Sz')
-    coupling = heisenberg_coupling([spin_site, spin_site], J=1.0)
-
-    coupling_hash = coupling.to_hash()
-    hash_key = ('coupling', coupling_hash)
-
-    start_key = ('coupling', coupling_hash, 0, 'start')
-
-    returned_keys = []
-
-    i, j = 0, 3
-    keyL = keyR = start_key
-    for k in range(i + 1, j):
-        if (k - i) % 4 == 0:
-            keyR = keyL + (k, hash_key, 'Id')
-        if not (keyL, keyR) in [(('a', 'b'), ('c', 'd'))]:
-            returned_keys.append((k, keyL, keyR))
-        keyL = keyR
-
-    assert len(returned_keys) == 2
-    assert returned_keys[0][0] == 1
-    assert returned_keys[1][0] == 2
-
-
-def test_add_missing_IdL_IdR_logic():
-    """Test add_missing_IdL_IdR for coupling hashes.
-    """
-    L = 4
-    graph = [{} for _ in range(L)]
-    states = [set() for _ in range(L + 1)]
-
-    graph[0][('IdL',)] = {('IdL',): [('Id', 1.0)]}
-    graph[2][('coupling', 'hash123')] = {('coupling', 'hash123'): [('op', 1.0)]}
-
-    insert_all_id = True
-    max_IdL = L
-    min_IdR = 0
-
-    for k in range(0, max_IdL):
-        if ('IdL', 'IdL') not in [(key, rkey) for key in graph[k] for rkey in graph[k][key]]:
-            if 'IdL' not in graph[k]:
-                graph[k]['IdL'] = {}
-            graph[k]['IdL']['IdL'] = [('Id', 1.0)]
-
-    for k in range(min_IdR, L):
-        if ('IdR', 'IdR') not in [(key, rkey) for key in graph[k] for rkey in graph[k][key]]:
-            if 'IdR' not in graph[k]:
-                graph[k]['IdR'] = {}
-            graph[k]['IdR']['IdR'] = [('Id', 1.0)]
-
-    assert ('IdL', 'IdL') in [(key, rkey) for key in graph[0] for rkey in graph[0][key]]
-    assert ('IdR', 'IdR') in [(key, rkey) for key in graph[3] for rkey in graph[3][key]]
+    site = site_factory()
+    creator = site.get_creator_numpy(species=0, include_JW=True)
+    annihilator = site.get_annihilator_numpy(species=0, include_JW=True)
+    JW = site._JW
+
+    # forward: coupling on [site, site] representing Cd_0 C_1 (JW dressing on the first operand)
+    h_fwd = (creator @ JW)[:, None, None, :] * annihilator[None, :, :, None]
+    coupling_fwd = couplings.Coupling.from_dense_block(h_fwd, [site, site], understood_braiding=True)
+
+    # independently-built coupling for the *reversed* site order, representing C_1 Cd_0: same
+    # construction principle, but now the annihilator is the first operand and gets the JW dressing
+    h_rev = (annihilator @ JW)[:, None, None, :] * creator[None, :, :, None]
+    coupling_rev = couplings.Coupling.from_dense_block(h_rev, [site, site], understood_braiding=True)
+
+    permuted = coupling_fwd.permute([1, 0], levels=[1, 2], over_braid=[None])
+
+    labels = ['p0', 'p1', 'p0*', 'p1*']
+    dim_permuted = permuted.to_tensor().to_numpy(labels, understood_braiding=True)
+    dim_rev = coupling_rev.to_tensor().to_numpy(labels, understood_braiding=True)
+    np.testing.assert_allclose(dim_permuted, expected_sign * dim_rev, atol=1e-10, err_msg=label)
+    # sanity: the *wrong* sign should NOT match (guards against a vacuously-passing all-zero case)
+    assert np.max(np.abs(dim_rev)) > 1e-10
+    assert not np.allclose(dim_permuted, -expected_sign * dim_rev, atol=1e-10)


### PR DESCRIPTION
Replace Coupling.to_hash/from_hash with __hash__/__eq__/__repr__ via _key().
Add Coupling.permute (leg/site reordering) and insert_identity_between_sites.
Tests in test_couplings.py.